### PR TITLE
Improve giiker move counting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /dist
+/.idea
+cstimer.iml

--- a/src/js/timer.js
+++ b/src/js/timer.js
@@ -871,8 +871,8 @@ var timer = execMain(function(regListener, regProp, getProp, pretty, ui, pushSig
 		var div = $('<div />');
 		var totPhases = 1;
 		var currentFacelet = mathlib.SOLVED_FACELET;
-		var moveCnt;
-		var lastAxes = 0;
+
+		var rawMoves = [];
 
 		var giikerVRC = (function() {
 			var twistyScene;
@@ -992,11 +992,6 @@ var timer = execMain(function(regListener, regProp, getProp, pretty, ui, pushSig
 			if (enableVRC) {
 				giikerVRC.setState(facelet, prevMoves, false);
 			}
-			var curAxis = "URFDLB".indexOf(prevMoves[0][0]);
-			if ((lastAxes & (0x20 >> curAxis)) == 0) {
-				lastAxes = lastAxes & (0x124 >> curAxis) | (0x20 >> curAxis);
-				moveCnt++;
-			}
 			clearReadyTid();
 			if (status == -1) {
 				if (facelet != mathlib.SOLVED_FACELET) {
@@ -1039,6 +1034,8 @@ var timer = execMain(function(regListener, regProp, getProp, pretty, ui, pushSig
 				ui.setAutoShow(false);
 			}
 			if (status >= 1) {
+				rawMoves[status] = (rawMoves[status] || "") + prevMoves[0]
+
 				var curProgress = cubeutil.getProgress(facelet, kernel.getProp('vrcMP', 'n'));
 				if (curProgress < status) {
 					for (var i = status; i > curProgress; i--) {
@@ -1048,6 +1045,13 @@ var timer = execMain(function(regListener, regProp, getProp, pretty, ui, pushSig
 				status = Math.min(curProgress, status) || 1;
 				lcd.setStaticAppend(lcd.getMulPhaseAppend(status, totPhases));
 				if (facelet == mathlib.SOLVED_FACELET) {
+					var prettyMoves = giikerutil.getPrettyMoves(rawMoves.reverse());
+					rawMoves.reverse();
+					var solve = prettyMoves.join("");
+					var moveCnt = giikerutil.getMoveCount(solve);
+
+					giikerutil.setLastSolve(solve);
+
 					status = -1;
 					curTime[1] = now - startTime;
 					ui.setAutoShow(true);
@@ -1073,7 +1077,7 @@ var timer = execMain(function(regListener, regProp, getProp, pretty, ui, pushSig
 				}
 				status = -2;
 				startTime = now;
-				moveCnt = 0;
+				rawMoves = [];
 				lcd.fixDisplay(true, true);
 				if (checkUseIns()) {
 					lcd.setRunning(true, enableVRC);


### PR DESCRIPTION
Hi! I have a Giiker I3S cube and I noticed that the move counting is off especially when I use slice moves.

So I improved the logic that was used for move counting.
Basically I detect sequences (like F B') and convert them to a slice move (for F B' it is S')
And also I transform the moves after because the Giiker cube assumes that your cube is always white on top and green forward.

And I also count double moves as one move.

It can still misinterpret some moves (R2 M2 is sometimes detected as R M R M or an R (pause) R is treated as R2) but I think it could only be improved if I take timestamps into account.

I also add a new link in the Giiker tool that always points to the last solve in alg.cubing.net and for setup uses the actual scramble as it is stored in the statistics.

Motivation:
My original plan was to add move count and tps to each phase of the solution so this is just a first step that fixes the move counting. My future plans:
- add move count and tps for each phase as a table inside Giiker tool ui
- add CFFFFOOPP multi-phase option for 2 look OLL and 2 look PLL
- store moves, move count, and tps and display it as part of the session statistic
- experiment with move count that also takes the timestamps of each move into consideration