### PR TITLE
fix unexpected inspection start by “A” signal header which stackmat G4 send regularly

### DIFF
--- a/src/js/timer.js
+++ b/src/js/timer.js
@@ -558,7 +558,7 @@ var timer = execMain(function(regListener, regProp, getProp, pretty, ui, pushSig
 				status = 1;
 				startTime = now - curTime;
 				ui.setAutoShow(false);
-			} else if (status == -1 && checkUseIns() && curTime == 0 && (state.rightHand || state.leftHand)) {
+			} else if (status == -1 && checkUseIns() && curTime == 0 && (state.signalHeader == 'R' || state.signalHeader == 'L')) {
 				status = -3;
 				ui.setAutoShow(false);
 				startTime = now;


### PR DESCRIPTION
Stackmat Gen4 seems to send “A” signalHeader per some minutes.
csTimer starts Inspection when it received “A” signalHeader because the signal makes both state.rightHand and state.leftHand true.
Please also see #171