### PR TITLE
Reset timer LCD when scramble is marked and before solve start

### DIFF
--- a/src/js/timer.js
+++ b/src/js/timer.js
@@ -1270,6 +1270,7 @@ var timer = execMain(function(regListener, regProp, getProp, pretty, ui, pushSig
 				}
 				totPhases = status;
 				curTime = [insTime > 17000 ? -1 : (insTime > 15000 ? 2000 : 0)];
+				lcd.reset(enableVRC);
 				lcd.fixDisplay(false, true);
 				lcd.setRunning(true, enableVRC);
 				ui.setAutoShow(false);
@@ -1321,6 +1322,7 @@ var timer = execMain(function(regListener, regProp, getProp, pretty, ui, pushSig
 				}
 				status = -2;
 				startTime = now;
+				lcd.reset(enableVRC);
 				lcd.fixDisplay(true, true);
 				if (checkUseIns()) {
 					lcd.setRunning(true, enableVRC);


### PR DESCRIPTION
When using timer with smartcubes and multi-phase reconstruction, if `Show virtual bluetooth cube` option is disabled, `rightDiv` of lcd is never emptied and infinitely being appended by each solve result. Also if inspection is enabled, inspection messages displayed in `rightDiv` isn't being cleared and appears above result. Screenshots below.
Fixed it just by resetting timer lcd after scramble is marked and right before solve start.

<img width="1552" alt="Screen Shot 2023-03-21 at 00 06 39 " src="https://user-images.githubusercontent.com/4266693/226467957-7bb4eda9-645a-437b-b0e6-9bc4a7b924e2.png">
<img width="1552" alt="Screen Shot 2023-03-21 at 00 11 07 " src="https://user-images.githubusercontent.com/4266693/226467976-6ea12db0-98e1-485a-8b6d-c48b8df7d2e2.png">
