### PR TITLE
Improvements for the Bluetooth Cube tool

### DIFF
--- a/src/js/bluetooth.js
+++ b/src/js/bluetooth.js
@@ -826,7 +826,7 @@ var GiikerCube = execMain(function() {
 		}
 
         return chkAvail.then(function(available) {
-			console.log(available);
+			DEBUG && console.log('[bluetooth]', 'is available', available);
             if (!available) {
                 return Promise.reject("Bluetooth is not available. Ensure HTTPS access, and check bluetooth is enabled on your device");
 			}


### PR DESCRIPTION
Some improvements to the Bluetooth Cube tool.

1. Raw Data link generation should rely on actual scramble length, not on constant value of 20 raw moves. Because scramble can be less than 20 raw moves, or even more. For example link generation would fail with such test case:
    - Apply arbitrary small scramble to the cube, for example simple 4 moves RUR'U'
    - Mark cube scrambled by pressing spacebar
    - Solve cube with 4 moves URU'R' and observe that Raw Data link is not generated correctly

2. Improve Last Solve link to be more clear and reflect actual state:
    - Display 'N/A' w/o active link by default
    - If cube successfully scrambled, display "In Progress" w/o active link
    - If cube solved, display "Ready" with link to reconstruction

4. Visual improvements. When Virtual Bluetooth Cube is disabled, Bluetooth Cube tool shows cube state, and it does not fit to the view. Font size used by default is so big and wastes space. So when Virtual Cube is disabled, font size for Bluetooth Cube tool is decreased by the factor of 1.5.

Before:
<img width="1552" alt="Screen Shot 2023-03-26 at 17 15 26 " src="https://user-images.githubusercontent.com/4266693/227783452-a4282104-96ce-4aeb-870b-a71a3c8f2c9b.png">
After:
<img width="1552" alt="Screen Shot 2023-03-26 at 17 23 17 " src="https://user-images.githubusercontent.com/4266693/227783456-93849948-fd52-49e8-bbde-4f1b4a1fb9d6.png">
