### PR TITLE
Fix reconstruction link click processing

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -506,6 +506,10 @@ html:not(.m) .mywindow:hover, html:not(.m) #leftbar:hover {
 	border-radius: 0.15em;
 }
 
+a {
+	color: inherit;
+}
+
 .click, .times, .tab, .table, .mybutton, .tabValue, .expOauth, .title, #touch, #lcd {
 	-webkit-touch-callout: none;
 	-webkit-user-select: none;

--- a/src/js/stats/recons.js
+++ b/src/js/stats/recons.js
@@ -2,7 +2,7 @@ var recons = execMain(function() {
 	var isEnable;
 
 	var div = $('<div style="font-size:0.9em;" />');
-	var reconsClick = $('<div>').append('<a target="_blank" class="click"></a>');
+	var reconsClick = $('<div>').append('<a target="_blank" class="exturl click"></a>');
 	var table = $('<table class="table">');
 	var rangeSelect = $('<select>');
 	var methodSelect = $('<select>');
@@ -297,7 +297,7 @@ var recons = execMain(function() {
 			return;
 		}
 		var target = $(e.target);
-		if (!target.is('.click')) {
+		if (!target.is('.click') || target.is('.exturl')) {
 			return;
 		}
 		if (!target.is('.sstep')) {


### PR DESCRIPTION
1. When pressing on reconstruction link which was moved inside recons table, `procClick` click processing interpret that click just like `requestBack` click, and perform `update()` resetting table state just before browser actually process and open external URL assigned to href. As a consequence link being opened is a link to the latest solve, not on actually displayed in table.

2. In some places like About dialog and newly added bluetooth instructions there exists `<a href>` links w/o `click` or any other css class specified. By default these links uses default navigator font color, which made them unreadable in most color schemes. So just set default color for links to inherit color from parent container.

BTW, regarding turn counting in reconstruction tool.. Seems like you doing some big refactoring there, so I won't doing changes there early. Just testing how it works and realize that turn counting doesn't handle subsequent face turns that cancels each other. For example I got this sequence that after being simplified by `getPrettyMoves` counted as 7 moves: `R D R' D' F' D' F // f2l'1 7 move(s)`. It has following raw sequence `R D' R' R D' D' R' D' F' D' F` which counts by reconstruction tool as 9 moves because it does not cancel `R'R` move and count this sequence as 9 moves.
