### PR TITLE
Fix time skew adjustment for GAN smart cubes

### DIFF
--- a/src/js/timer.js
+++ b/src/js/timer.js
@@ -100,7 +100,7 @@ var timer = execMain(function(regListener, regProp, getProp, pretty, ui, pushSig
 			if (status == -3 || (status == -2 && checkUseIns())) {
 				setHtml(runningDiv, (getProp('timeU') != 'n' ? ((time > 17000) ? 'DNF' : (time > 15000) ? '+2' : 15 - ~~(time / 1000)) : TIMER_INSPECT) + curAppend);
 			} else { //>0
-				var pret = pretty(time, true);
+				var pret = pretty(time > 0 ? time : 0, true);
 				setHtml(runningDiv, {
 					'u': pret,
 					'c': pret.replace(/([.>])(\d)\d+(<|$)/, "$1$2$3"),


### PR DESCRIPTION
Sometimes I get weird time skew behavior. Especially when my macbook running under heavy load (streaming/recording for example). Check attached video below.
- Timer LCD start its counting not from zero, but from 1.7 seconds for example. During solve display shows time slightly ahead, and after solve finished this time is trimmed back.
- Sometimes LCD start counting displaying DNF.

The problem is in the time skew handling which amount can become large enough, but still less than 2000ms. For example this typical sequence lead to cube initialized with such big time skew:

  1. Reload csTimer page, `Performance.now()` start its counting from zero.
  2. Within some amount of time < 2000ms rotate cube face (so next cube move will have time offset from this point)
  3. Connect cube and then rotate face. At this point time skew adjustment won't be called because it will be < 2000ms, but can be large enough and equals to gap between 1 and 2 steps.

So to avoid this I made some changes:

  - Upon cube connection/initialization reset all state variables including timestamp base.
  - Forcibly call time skew adjustment once after cube was initialized.
  - For convenience add method to forcibly invoke time skew adjustment by rotating cube faces `UU'UU'UU'`
  - Time skew can be negative, so fixed LCD to avoid displaying DNF if time is negative and timer is running.

https://user-images.githubusercontent.com/4266693/228978225-5bebd860-26b0-4c44-a162-f7b2f349727b.mp4
