### PR TITLE
Improve GAN v2 bluetooth protocol handling

### DIFF
--- a/src/js/tools/bluetoothutil.js
+++ b/src/js/tools/bluetoothutil.js
@@ -194,14 +194,18 @@ var giikerutil = execMain(function(CubieCube) {
 	var batId = 0;
 	var batValue = 0;
 
-	function updateBattery() {
+	function updateBattery(value) {
+		batValue = value[0];
+		connectedStr = value[1] + ': Connected | ' + (batValue || '??') + '%';
+		connectClick.html(connectedStr);
+	}
+
+	function pollUpdateBattery() {
 		if (GiikerCube.isConnected()) {
 			GiikerCube.getCube().getBatteryLevel().then(function(value) {
-				batValue = value[0];
-				connectedStr = value[1] + ': Connected | ' + (batValue || '??') + '%';
-				connectClick.html(connectedStr);
+				updateBattery(value);
 			});
-			batId = setTimeout(updateBattery, 60000);
+			batId = setTimeout(pollUpdateBattery, 60000);
 		} else {
 			batId = 0;
 		}
@@ -338,7 +342,7 @@ var giikerutil = execMain(function(CubieCube) {
 			scrambleLength = 0;
 		}
 		drawState();
-		batId == 0 && updateBattery();
+		batId == 0 && pollUpdateBattery();
 		giikerErrorDetect();
 		var retState = curState;
 		if (hackedSolvedCubieInv) {
@@ -486,6 +490,7 @@ var giikerutil = execMain(function(CubieCube) {
 		init: init,
 		isSync: isSync,
 		reSync: reSync,
+		updateBattery: updateBattery,
 		setLastSolve: setLastSolve
 	}
 }, [mathlib.CubieCube]);


### PR DESCRIPTION
1. Seems like it is better to remove `advertisementreceived` event listener during cleanup procedure, because listener persists there until page reload, and will be invoked on subsequent device disconnection/connection.
2. Little refactor for GAN v2 protocol handling, added some commands like 'hardware info' and 'reset' which may be useful in the future.
3. Request battery status upon connection, also little refactor for Bluetooth Cube tool to allow setting battery level in push fashion, right on receiving battery level event from cube.