### PR TITLE
Make right LCD padding consistent across timers

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -529,6 +529,10 @@ a {
 	z-index: 10;
 }
 
+#multiphase {
+	padding-right: 0.75rem;
+}
+
 #about {
 	line-height: 1.6em;
 	text-align: left;

--- a/src/js/timer.js
+++ b/src/js/timer.js
@@ -113,9 +113,9 @@ var timer = execMain(function(regListener, regProp, getProp, pretty, ui, pushSig
 			if (status == -3 || status == -2) { //inspection alert
 				if (runningDiv !== rightDiv) {
 					if (time >= 12000) {
-						setHtml(rightDiv, '<div style="font-family: Arial;">Go!!!&nbsp;&nbsp;</div>');
+						setHtml(rightDiv, '<div style="font-family: Arial;">Go!!!</div>');
 					} else if (time >= 8000) {
-						setHtml(rightDiv, '<div style="font-family: Arial;">8s!&nbsp;&nbsp;</div>');
+						setHtml(rightDiv, '<div style="font-family: Arial;">8s!</div>');
 					}
 				}
 				if (getProp('voiceIns') != 'n') {
@@ -334,7 +334,7 @@ var timer = execMain(function(regListener, regProp, getProp, pretty, ui, pushSig
 				lastDown = now;
 				curTime[status] = lastDown - startTime;
 				getProp('phases') != status && lcd.append('+');
-				getProp('phases') != 1 && lcd.append(pretty(curTime[status] - ~~curTime[status + 1], true) + '&nbsp;<br>');
+				getProp('phases') != 1 && lcd.append(pretty(curTime[status] - ~~curTime[status + 1], true) + '<br>');
 				if (keyCode == 27) {
 					var times = [-1],
 						i = 1;


### PR DESCRIPTION
Messages displayed on LCD in rightDiv have inconsistent right edge padding across timers. Keyboard timer uses `&nbsp;` to pad messages, virtual/smartcube timers have no padding at all. Fixed this so they look the same.