### PR TITLE
Prevent screen from sleeping while csTimer is active

### DIFF
--- a/src/js/kernel.js
+++ b/src/js/kernel.js
@@ -848,6 +848,22 @@ var kernel = execMain(function() {
 			if (location.protocol != 'https:') {
 				document.title = '[UNSAFE] ' + document.title;
 			}
+			if (navigator.wakeLock && navigator.wakeLock.request) {
+				var requestWakeLock = function () {
+					return navigator.wakeLock.request('screen').then(function (lock) {
+						DEBUG && console.log('[ui]', 'Screen Wake Lock is active');
+						lock.addEventListener('release', function () {
+							DEBUG && console.log('[ui]', 'Screen Wake Lock is released');
+						});
+					});
+				};
+				requestWakeLock();
+				document.addEventListener('visibilitychange', function () {
+					if (document.visibilityState === 'visible') {
+						requestWakeLock();
+					}
+				});
+			}
 		});
 
 		return {


### PR DESCRIPTION
While playing with smartcube on mobile get annoyed by turning off screen, because you don't touch the device like with normal timer. Also same happens using GAN Timer, and even on desktop. So this is common approach for PWA to keep screen on while application is active, more info here: https://web.dev/wake-lock/