### PR TITLE
Ability to disconnect from cube in the Bluetooth Cube tool

### DIFF
--- a/src/js/bluetooth.js
+++ b/src/js/bluetooth.js
@@ -751,9 +751,10 @@ var GiikerCube = execMain(function() {
 			_service_data = null;
 			_service_meta = null;
 			_service_v2data = null;
+			var result = Promise.resolve();
 			if (_chrct_v2read) {
 				_chrct_v2read.removeEventListener('characteristicvaluechanged', onStateChangedV2);
-				_chrct_v2read.stopNotifications();
+				result = _chrct_v2read.stopNotifications();
 				_chrct_v2read = null;
 			}
 			deviceMac = null;
@@ -765,6 +766,7 @@ var GiikerCube = execMain(function() {
 			prevTimestamp = 0;
 			prevMoveCnt = -1;
 			batteryLevel = 100;
+			return result;
 		}
 
 		return {
@@ -1091,12 +1093,13 @@ var GiikerCube = execMain(function() {
 
 	function stop() {
 		if (!_device) {
-			return;
+			return Promise.resolve();
 		}
-		cube && cube.clear();
-		_device.removeEventListener('gattserverdisconnected', onDisconnect);
-		_device.gatt.disconnect();
-		_device = null;
+		return Promise.resolve(cube && cube.clear()).then(function () {
+			_device.removeEventListener('gattserverdisconnected', onDisconnect);
+			_device.gatt.disconnect();
+			_device = null;
+		});
 	}
 
 	var callback = $.noop;

--- a/src/js/tools/bluetoothutil.js
+++ b/src/js/tools/bluetoothutil.js
@@ -322,7 +322,7 @@ var giikerutil = execMain(function(CubieCube) {
 	function giikerCallback(facelet, prevMoves, lastTimestamp, hardware) {
 		lastTimestamp = lastTimestamp || $.now();
 		connectedStr = hardware + ': Connected | ' + (batValue || '??') + '%';
-		connectClick.html(connectedStr).removeClass('click').unbind('click');
+		connectClick.html(connectedStr).addClass('click').unbind('click').click(disconnect);
 		curRawState = facelet;
 		curRawCubie.fromFacelet(curRawState);
 		CubieCube.EdgeMult(solvedStateInv, curRawCubie, curCubie);
@@ -406,6 +406,14 @@ var giikerutil = execMain(function(CubieCube) {
 			return GiikerCube.init();
 		} else {
 			return Promise.resolve();
+		}
+	}
+
+	function disconnect() {
+		if (GiikerCube.isConnected() && confirm("Disconnect?")) {
+			GiikerCube.stop().then(function () {
+				evtCallback('disconnect');
+			});
 		}
 	}
 


### PR DESCRIPTION
1. GAN v2 internal cube state can be reseted to solved state by sending corresponding command to the cube. So for this type of cubes `Reset (Mark Solved)` button of the Bluetooth Cube tool will send such command. On this command cube respond with facelets (cube state) message, so state is updated accordingly.

2. Ability to disconnect from cube in the Bluetooth Cube tool by clicking on the same `connectClick` link used for connect. It is little more convenient for PWA rather than closing/reopening application. Also little refactoring for proper handling of disconnection.