### PR TITLE
Some useful UI tweaks

### DIFF
--- a/src/js/stats/stats.js
+++ b/src/js/stats/stats.js
@@ -1559,7 +1559,7 @@ var stats = execMain(function(kpretty, round, kpround) {
 			} else if (value[0] == 'statsrc') {
 				times_stats_table = new TimeStat(avgSizes, times.length, getTableTimeAt());
 				updateUtil(['property', value[0]]);
-			} else if (value[0] == 'wndStat') {
+			} else if (value[0] == 'wndStat' || value[0] == 'statScale') {
 				resultsHeight();
 			} else if (value[0] == 'sr_statal') {
 				kernel.setProp('sr_statalu', value[1]);
@@ -1584,6 +1584,7 @@ var stats = execMain(function(kpretty, round, kpround) {
 	}
 
 	function resultsHeight() {
+		div.css('font-size', kernel.getProp('statScale') + '%');
 		if ($('html').hasClass('m')) {
 			scrollDiv.height(Math.max(sumtableDiv.height(), avgRow.height() + title.height() * 2));
 		} else if (scrollDiv[0].offsetParent != null) {
@@ -1595,10 +1596,12 @@ var stats = execMain(function(kpretty, round, kpround) {
 		kernel.regListener('stats', 'time', procSignal);
 		kernel.regListener('stats', 'scramble', procSignal);
 		kernel.regListener('stats', 'scrambleX', procSignal);
-		kernel.regListener('stats', 'property', procSignal, /^(:?useMilli|timeFormat|stat(:?sum|thres|[12][tl]|alu?|inv|Hide|src)|session(:?Data)?|scrType|phases|trim|view|wndStat|sr_.*)$/);
+		kernel.regListener('stats', 'property', procSignal, /^(:?useMilli|timeFormat|stat(:?sum|thres|[12][tl]|alu?|inv|Hide|src)|session(:?Data)?|scrType|phases|trim|view|wndStat|statScale|sr_.*)$/);
 		kernel.regListener('stats', 'ctrl', procSignal, /^stats$/);
 		kernel.regListener('stats', 'ashow', procSignal);
 		kernel.regListener('stats', 'button', procSignal);
+		// TODO: i18n
+		kernel.regProp('ui', 'statScale', 2, "Statistics panel display scale %", [100, 1, 200]);
 
 		kernel.regProp('stats', 'trim', 1, PROPERTY_TRIM, ['p5', ['1', 'p1', 'p5', 'p10', 'p20', 'm'], ['1', '1%', '5%', '10%', '20%', PROPERTY_TRIM_MED]], 1);
 		kernel.regProp('stats', 'statsum', 0, PROPERTY_SUMMARY, [true], 1);

--- a/src/js/timer.js
+++ b/src/js/timer.js
@@ -1526,6 +1526,10 @@ var timer = execMain(function(regListener, regProp, getProp, pretty, ui, pushSig
 				virtual333.setSize(value[1]);
 				giikerTimer.setSize(value[1]);
 			}
+			if (value[0] == 'timerYOffset') {
+				$('#container').closest('table').css('top', value[1] + '%');
+				$('#multiphase').closest('table').css('top', value[1] + '%');
+			}
 			if (value[0] == 'timerSize' || value[0] == 'phases') {
 				$('#multiphase').css('font-size', getProp('timerSize') / Math.max(getProp('phases'), 4) + 'em')
 			}
@@ -1543,7 +1547,17 @@ var timer = execMain(function(regListener, regProp, getProp, pretty, ui, pushSig
 			if ($.inArray(value[0], resetCondition) != -1) {
 				reset();
 			}
-		}, /^(?:input|phases|scrType|preScr|timerSize|showAvg|useMilli|smallADP|giiVRC)$/);
+		}, /^(?:input|phases|scrType|preScr|timerSize|timerYOffset|showAvg|useMilli|smallADP|giiVRC)$/);
+		regListener('timer', 'ashow', function (signal, value) {
+			var timerYOffset = kernel.getProp('timerYOffset');
+			if (value) {
+				$('#container').closest('table').css('top', timerYOffset + '%');
+				$('#multiphase').closest('table').css('top', timerYOffset + '%');
+			} else {
+				$('#container').closest('table').css('top', '0');
+				$('#multiphase').closest('table').css('top', '0');
+			}
+		});
 		regProp('vrc', 'vrcSpeed', 1, PROPERTY_VRCSPEED, [100, [0, 50, 100, 200, 500, 1000], '\u221E|20|10|5|2|1'.split('|')], 1);
 		regProp('vrc', 'vrcOri', ~1, 'PROPERTY_VRCORI', ['6,12', ['6,12', '10,11'], ['UF', 'URF']], 1);
 		regProp('vrc', 'vrcMP', 1, PROPERTY_VRCMP, ['n', ['n', 'cfop', 'fp', 'cf4op', 'cf4o2p2', 'roux'], PROPERTY_VRCMPS.split('|')], 1);
@@ -1567,6 +1581,8 @@ var timer = execMain(function(regListener, regProp, getProp, pretty, ui, pushSig
 		regProp('timer', 'phases', 2, PROPERTY_PHASES, [1, 1, 10], 3);
 		regProp('kernel', 'showAvg', 0, SHOW_AVG_LABEL, [true], 1);
 		regProp('ui', 'timerSize', 2, PROPERTY_TIMERSIZE, [20, 1, 100], 1);
+		// TODO: i18n
+		regProp('ui', 'timerYOffset', 2, 'timer vertical offset %', [0, -50, 50]);
 		regProp('ui', 'smallADP', 0, PROPERTY_SMALLADP, [true], 1);
 	});
 

--- a/src/js/tools/tools.js
+++ b/src/js/tools/tools.js
@@ -7,6 +7,7 @@ var tools = execMain(function() {
 	var divs = [];
 
 	function execFunc(idx, signal) {
+		updateStyles();
 		if (idx == -1) {
 			for (var i = 0; i < kernel.getProp('NTools'); i++) {
 				execFunc(i, signal);
@@ -26,6 +27,23 @@ var tools = execMain(function() {
 				toolBox[tool](fdivs[idx], signal);
 			}
 		}
+	}
+
+	function updateStyles() {
+		// invoke async to ensure animation was finished and state is updated
+		setTimeout(function () {
+			$('#toolsDiv').css('font-size', kernel.getProp('toolScale') + '%');
+			if (kernel.getProp('toolPos') == 't') {
+				var scrambleHeight = $('#scrambleDiv').is(':visible') ? ($('#scrambleDiv').outerHeight() - 1) : 0;
+				$('#toolsDiv')
+					.css('top', scrambleHeight)
+					.css('bottom', 'auto');
+			} else {
+				$('#toolsDiv')
+					.css('top', '')
+					.css('bottom', '');
+			}
+		}, 0);
 	}
 
 	function disableFunc(idx, signal) {
@@ -183,6 +201,8 @@ var tools = execMain(function() {
 					funcMenu[i].loadVal(newfuncs[i]);
 				}
 				onFuncSelected();
+			} else if (value[0] == 'toolPos' || value[0] == 'toolScale' || value[0] == 'scrHide') {
+				updateStyles();
 			}
 		} else if (signal == 'scramble' || signal == 'scrambleX') {
 			curScramble = value;
@@ -198,6 +218,8 @@ var tools = execMain(function() {
 					execFunc(i, signal);
 				}
 			}
+		} else if (signal == 'scrfix' || (signal == 'button' && value[0] == 'scramble')) {
+			updateStyles();
 		}
 	}
 
@@ -219,20 +241,28 @@ var tools = execMain(function() {
 	}
 
 	$(function() {
-		kernel.regListener('tools', 'property', procSignal, /^(?:imgSize|image|toolsfunc|NTools|col(?:cube|pyr|skb|sq1|mgm)|toolHide)$/);
+		kernel.regListener('tools', 'property', procSignal, /^(?:imgSize|image|toolsfunc|NTools|toolPos|toolScale|col(?:cube|pyr|skb|sq1|mgm)|toolHide|scrHide)$/);
 		kernel.regListener('tools', 'scramble', procSignal);
 		kernel.regListener('tools', 'scrambleX', procSignal);
-		kernel.regListener('tools', 'button', procSignal, /^tools$/);
+		kernel.regListener('tools', 'scrfix', procSignal);
+		kernel.regListener('tools', 'button', procSignal, /^(?:tools|scramble)$/);
 
 		var mainDiv = $('<div id="toolsDiv"/>');
 		for (var i = 0; i < 4; i++) {
 			fdivs[i].click(showFuncSpan);
 			funcSpan[i].append("<br>", TOOLS_SELECTFUNC, funcMenu[i].select1, funcMenu[i].select2);
 			divs[i].append(fdivs[i], funcSpan[i]).appendTo(mainDiv);
-			if (i == 1) {
+			if (!kernel.getProp('toolRow') && i == 1) {
 				mainDiv.append('<br>');
 			}
 		}
+
+		// TODO: i18n
+		kernel.regProp('ui', 'toolRow', 0, "Display Tools in row", [false]);
+		// TODO: i18n
+		kernel.regProp('ui', 'toolPos', 1, "Tools panel position", ['b', ['b', 't'], ['Bottom', 'Top']]);
+		// TODO: i18n
+		kernel.regProp('ui', 'toolScale', 2, "Tools panel display scale %", [100, 1, 200]);
 
 		kernel.regProp('tools', 'solSpl', 0, PROPERTY_HIDEFULLSOL, [false]);
 		kernel.regProp('tools', 'imgSize', 2, PROPERTY_IMGSIZE, [15, 5, 50]);


### PR DESCRIPTION
This is some tweaks that users can apply to csTimer UI. They are especially useful on mobile.
One of the problem they solve, reconstruction tool is unusable on mobile because it overlaps with statistics panel. You can't select specific solve and then view it in reconstruction even using buttons to show/hide panels. Also screen space can be used more efficiently at the user's discretion.

1. Set position of the Tools panel: Top or Bottom of the screen.
2. Set display scale of the Tools panel.
3. Enable all 4 tools display in single row (useful for wide-screen displays).
4. Set display scale of the Statistics panel.
5. Set vertical offset of timer LCD display.

This is how UI can looks like on mobile using this tweaks:

<img width="400" src="https://user-images.githubusercontent.com/4266693/230895177-f642c133-4406-4aa1-b5b6-1952ddc66623.png">

Demo of using this tweaks:

https://user-images.githubusercontent.com/4266693/230895048-61041cf8-626e-4321-a1cb-4e944f00691c.mp4
