### PR TITLE
Fix timer auto-centering

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -677,6 +677,7 @@ div.helptable ul {
 	left: 190px;
 	left: 13.5rem;
 	top: 0;
+	width: 100%;
 }
 
 #scrambleDiv > .title {
@@ -1045,7 +1046,7 @@ html.m .mhide, html:not(.m) .mshow {
 }
 
 .m.toolf #toolsDiv {
-	margin-left: auto;
+	margin-left: 0;
 }
 
 .m.toolt #toolsDiv {

--- a/src/js/kernel.js
+++ b/src/js/kernel.js
@@ -758,7 +758,7 @@ var kernel = execMain(function() {
 					setColor(col_props.indexOf(value[0].substring(4, value[0].length)), value[1]);
 					break;
 				case 'zoom':
-					$('html').attr('class', 'p' + ~~(value[1] * 100));
+					$('html').removeClass('p70 p80 p90 p100 p110 p125 p150').addClass('p' + ~~(value[1] * 100));
 					$(window).trigger('resize');
 					updateUIDesign();
 				case 'view':


### PR DESCRIPTION
1. Properly calculate offset when auto-centering timer. Even if `div` is invisible, its `outerHeight` is not zero. So timer offset was not properly calculated, for example when scramble visibility is toggled.
2. Theoretically it is better to directly catch tools/stats/scramble divs resize events to update timer offset, but it's not so easy to implement. So basically handle all events which may affect size of that divs, and update timer offset accordingly. This also fixes issue with timer offset calculation on first page load, it was calculated based on stats div height not populated with any results.
3. Stretch scramble div to screen width to avoid empty space appearing on the right side when Tool panel is placed on Top.
4. Fixed issue with disappearing `toolf, toolt` classes on `html` when changing zoom.
5. IMHO when Tool panel is in Float mode, it looks better if stick it to the left edge of the screen. Otherwise you can rollback this by changing back to `margin-left: auto`.