### PR TITLE
Fix for replay link apperance

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -166,6 +166,13 @@ textarea {
 	font-size: 0.3em;
 }
 
+#multiphase .replay {
+	font-family: Arial;
+	font-size: 0.4em;
+	position: relative;
+	z-index: 20;
+}
+
 #avgstr > span {
 	position: relative;
 	display: inline-block;
@@ -537,11 +544,23 @@ a {
 	z-index: 10;
 }
 
-.insp.activetimer::after {
+#timer .insp.activetimer::after {
 	content: "\e6b6";
 	font-family: iconfont;
 	position: absolute;
 	font-size: 0.2em;
+	opacity: 0.65;
+}
+
+#rtimer .insp.activetimer::before {
+	content: "\e6b6";
+	font-family: iconfont;
+	position: absolute;
+	top: auto;
+	right: 0px;
+	padding-right: 0.75rem;
+	font-size: 0.2em;
+	opacity: 0.65;
 }
 
 .playbutton.click {

--- a/src/js/stats/recons.js
+++ b/src/js/stats/recons.js
@@ -37,12 +37,8 @@ var recons = execMain(function() {
 		this.moveCnt = 0;
 	}
 
-	function getMoveCnt(times) {
-		if (!times || !times[4]) {
-			return -1;
-		}
-		var solution = times[4];
-		solution = solution[0].split(/ +/);
+	function getMoveCnt(solution) {
+		solution = solution.split(/ +/);
 		var c = new mathlib.CubieCube();
 		c.ori = 0;
 		var cnter = new MoveCounter();


### PR DESCRIPTION
- Completely remove "replay link with turn count" code from avgDiv, it should not be tied to it.
- Display replay link with turn count in the rightDiv after successful solve was made with bluetooth or virtual puzzle.
- Fix inspection label appearance in the rightDiv.

Really wanted to remove moveCnt storing in the database. But left it for your decision. Actually seems like it is not used for now, only was needed when trying to tie replay link to avgDiv lifecycle. Maybe upon current release not try to pollute DB. And decide later if it's needed when the turn count refactoring is done.