### PR TITLE
Fix Bluetooth Cube tool disconnect/cleanup

### DIFF
--- a/src/js/bluetooth.js
+++ b/src/js/bluetooth.js
@@ -753,7 +753,7 @@ var GiikerCube = execMain(function() {
 			var result = Promise.resolve();
 			if (_chrct_v2read) {
 				_chrct_v2read.removeEventListener('characteristicvaluechanged', onStateChangedV2);
-				result = _chrct_v2read.stopNotifications();
+				result = _chrct_v2read.stopNotifications().catch($.noop);
 				_chrct_v2read = null;
 			}
 			deviceMac = null;
@@ -1024,10 +1024,13 @@ var GiikerCube = execMain(function() {
 	})();
 
 	function onHardwareEvent(info, event) {
+		var res = Promise.resolve();
 		if (info == 'disconnect') {
-			stop();
+			res = Promise.resolve(stop());
 		}
-		evtCallback && evtCallback(info, event);
+		return res.then(function () {
+			return typeof evtCallback == 'function' && evtCallback(info, event);
+		});
 	}
 
 	var onDisconnect = onHardwareEvent.bind(null, 'disconnect');

--- a/src/js/timer.js
+++ b/src/js/timer.js
@@ -1344,15 +1344,15 @@ var timer = execMain(function(regListener, regProp, getProp, pretty, ui, pushSig
 		return {
 			setEnable: function(input) { //s: stackmat, m: moyu
 				enable = input == 'g';
-				if (enable) {
+				if (enable && !GiikerCube.isConnected()) {
 					giikerutil.setCallback(giikerCallback);
 					kernel.showDialog([$('<div>Press OK To Connect To Bluetooth Cube</div>').append(bluetoothInstructDiv), function () {
 						giikerutil.init().catch(function(error) {
 							DEBUG && console.log('[giiker] init failed', error);
 						});
 					}, 0, 0], 'share', 'Bluetooth Connect');
-				} else {
-					GiikerCube.stop();
+				} else if (!enable) {
+					giikerutil.stop();
 				}
 				setVRC(enable && getProp('giiVRC') != 'n');
 			},

--- a/src/js/tools/bluetoothutil.js
+++ b/src/js/tools/bluetoothutil.js
@@ -179,6 +179,8 @@ var giikerutil = execMain(function(CubieCube) {
 	function renderStatus() {
 		if (!(kernel.getProp('giiVRC') != 'n')) {
 			statusDiv.css('font-size', '60%');
+		} else {
+			statusDiv.css('font-size', '');
 		}
 		statusDiv.empty();
 		statusDiv.append($('<tr>').append($('<td colspan=2>').append(connectClick)));
@@ -444,7 +446,7 @@ var giikerutil = execMain(function(CubieCube) {
 			moveTsStart = 0;
 		}
 		var param = tsLinearFit(moveTsList, true);
-		slopeTd.html(slopeIcon + Math.round((param[0] - 1) * 10000) / 100 + '%');
+		slopeTd.html(slopeIcon + Math.round((param[0] - 1) * 100000) / 1000 + '%');
 	}
 
 	function updateAlgClick(click, text, setup, alg) {
@@ -502,11 +504,19 @@ var giikerutil = execMain(function(CubieCube) {
 		}
 	}
 
-	function disconnect() {
-		if (GiikerCube.isConnected() && confirm("Disconnect?")) {
-			GiikerCube.stop().then(function () {
+	function stop() {
+		if (GiikerCube.isConnected()) {
+			return GiikerCube.stop().then(function () {
 				evtCallback('disconnect');
 			});
+		} else {
+			return Promise.resolve();
+		}
+	}
+
+	function disconnect() {
+		if (GiikerCube.isConnected() && confirm("Disconnect?")) {
+			stop();
 		}
 	}
 
@@ -530,8 +540,8 @@ var giikerutil = execMain(function(CubieCube) {
 				scrHinter.checkState(curCubie);
 			}
 		} else if (signal == 'property') {
-			if (value[0] == 'giiVRC') {
-				drawState();
+			if (['giiVRC', 'imgSize'].indexOf(value[0]) >= 0) {
+				renderStatus();
 			} else if (value[0] == 'preScr') {
 				scrHinter.setScramble(curScramble);
 				if (curScramble && kernel.getProp('input') == 'g') {
@@ -581,7 +591,7 @@ var giikerutil = execMain(function(CubieCube) {
 		kernel.regListener('giiker', 'scramble', procSignal);
 		kernel.regListener('giiker', 'scrambling', procSignal);
 		kernel.regListener('giiker', 'scrambleX', procSignal);
-		kernel.regListener('giiker', 'property', procSignal, /^(?:giiVRC|preScr)$/);
+		kernel.regListener('giiker', 'property', procSignal, /^(?:giiVRC|imgSize|preScr)$/);
 		tools.regTool('giikerutil', TOOLS_GIIKER, execFunc);
 	});
 
@@ -593,6 +603,7 @@ var giikerutil = execMain(function(CubieCube) {
 		checkScramble: checkScramble,
 		markScrambled: markScrambled,
 		init: init,
+		stop: stop,
 		isSync: isSync,
 		reSync: reSync,
 		tsLinearFix: tsLinearFix,

--- a/src/js/tools/bluetoothutil.js
+++ b/src/js/tools/bluetoothutil.js
@@ -164,7 +164,7 @@ var giikerutil = execMain(function(CubieCube) {
 			colors = kernel.getProp('colcube').match(/#[0-9a-fA-F]{3}/g);
 			canvasTd.show();
 			ctx = canvas[0].getContext('2d');
-			var imgSize = kernel.getProp('imgSize') / 50;
+			var imgSize = kernel.getProp('imgSize') / 60;
 			canvas.width(39 * imgSize + 'em');
 			canvas.height(29 * imgSize + 'em');
 			canvas.attr('width', 39 * 3 / 9 * width + 1);
@@ -178,7 +178,7 @@ var giikerutil = execMain(function(CubieCube) {
 
 	function renderStatus() {
 		if (!(kernel.getProp('giiVRC') != 'n')) {
-			statusDiv.css('font-size', 'calc(100% / 1.5)');
+			statusDiv.css('font-size', '60%');
 		}
 		statusDiv.empty();
 		statusDiv.append($('<tr>').append($('<td colspan=2>').append(connectClick)));
@@ -470,7 +470,24 @@ var giikerutil = execMain(function(CubieCube) {
 		}
 	}
 
+	function cleanup() {
+		batId = 0;
+		batValue = 0;
+		deviceName = null;
+		curRawState = mathlib.SOLVED_FACELET;
+		curRawCubie = new CubieCube();
+		curCubie = new CubieCube();
+		curState = curRawState;
+		solvedStateInv = new CubieCube();
+		moveTsList = [];
+		moveTsStart = 0;
+		slopeTd.html(slopeIcon + '0%');
+		updateAlgClick(algCubingClick, "Raw(N/A)");
+		updateAlgClick(lastSolveClick, "Pretty(N/A)");
+	}
+
 	function init() {
+		cleanup();
 		curRawState = kernel.getProp('giiSolved', mathlib.SOLVED_FACELET);
 		curRawCubie.fromFacelet(curRawState);
 		solvedStateInv.invFrom(curRawCubie);


### PR DESCRIPTION
- Fix bluetooth disconnection procedure, which is not handled properly by Bluetooth Cube tool when cube is disconnected by itself on hardware event.
- Proper cleanup for all state variables in Bluetooth Cube tool upon new cube connection. So all things will work properly without reloading application page.
- Although the size of the cube state image displayed in Bluetooth Cube tool can be controlled by user using `imgSize` settings property, it's default value with overall default settings make this image being displayed out of bounds. So I just adjusted used coefficients to make state image fit to the view by default.

BTW I have noticed, that in the `bluetooth.js` only `GanCube` cube implementation has properly implemented `clear()` method, which used upon cube connection/disconnection and is crucial after cube was disconnected/connected without application page being reloaded. So it is better to implement such method for all cube types. Unfortunately I have only GAN cubes to test so I don't dare to make it.
