### PR TITLE
Fix for some GAN Smart Timers that may expose different bluetooth names on macOS

### DIFF
--- a/src/js/gantimer.js
+++ b/src/js/gantimer.js
@@ -133,7 +133,11 @@ var GanTimerDriver = execMain(function () {
 				return Promise.reject("Bluetooth is not available. Ensure HTTPS access, and check bluetooth is enabled on your device");
 		}).then(function () {
 			return navigator.bluetooth.requestDevice({
-				filters: [{ namePrefix: "GAN" }],
+				filters: [
+					{ namePrefix: "GAN" },
+					{ namePrefix: "gan" },
+					{ namePrefix: "Gan" }
+				],
 				optionalServices: [GAN_TIMER_SERVICE]
 			});
 		}).then(function (device) {


### PR DESCRIPTION
Some user faced issue that he unable to connect GAN Smart Timer using Chrome on **macOS**.

Cause of the problem is macOS Core Bluetooth, which behavior is differs from other platforms. It exposes to applications device name stored in device's `generic_access` service `gap.device_name` characteristic, not name that device sends in advertisement packet. Some GAN devices somehow has different names there. For example some GAN i3 cubes advertise them with unique names like GANi3faH, but has masked names like GANi3XXX stored in the `gap.device_name` characteristic value.

In this case we have user with GAN Smart Timer instance that advertise normally as 'GAN-xxxxx' but have just 'gan' string stored in `gap.device_name` characteristic. So on macOS such timer device presented in bluetooth selection dialog with that 'gan' name, and was filtered out.