### PR TITLE
Added popup dialog showing cases stats

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -800,6 +800,18 @@ div.helptable ul {
 	bottom: 20%;
 }
 
+.dialogcasestats {
+	left: 30%;
+	right: 30%;
+	top: 15%;
+	bottom: 15%;
+}
+
+.dialogcasestats .table {
+	width: 100%;
+	font-size: 1.5em;
+}
+
 .dialogssmgr {
 	left: 15%;
 	right: 15%;
@@ -1109,7 +1121,7 @@ html.m .mhide, html:not(.m) .mshow {
 	font-size: 1.2em;
 }
 
-.m .dialogoption, .m .dialogshare, .m .dialoginput, .m .dialogstats, .m .dialogssmgr, .m .dialogscropt, .m .dialogexport, .m .dialoglogo {
+.m .dialogoption, .m .dialogshare, .m .dialoginput, .m .dialogstats, .m .dialogcasestats, .m .dialogssmgr, .m .dialogscropt, .m .dialogexport, .m .dialoglogo {
 	left: 5%;
 	right: 5%;
 }


### PR DESCRIPTION
Since it is not so convenient in Reconstruction tool to switch mode back and forth to access cases statistics, I've added ability to show Cases Stats using popup dialog. This dialog is shown when clicking on the OLL/PLL headers of the step reconstruction table. Also this dialog adds button with function for exporting displayed Case Stats to JSON file.

<img src="https://github.com/cs0x7f/cstimer/assets/4266693/fd96d6ee-8085-40a2-a84a-6eb7269191a9" width=900>

<img src="https://github.com/cs0x7f/cstimer/assets/4266693/8daf6fde-60cc-46ca-82ee-3a1d1ef85b64" width=400>

