### PR TITLE
Fix for some edge cases that may occur with bluetooth cubes

### DIFF
--- a/src/js/bluetooth.js
+++ b/src/js/bluetooth.js
@@ -583,7 +583,7 @@ var GiikerCube = execMain(function() {
 			for (var i = moveDiff - 1; i >= 0; i--) {
 				calcTs += timeOffs[i];
 			}
-			if (Math.abs(locTime - calcTs) > 2000) {
+			if (!deviceTime || Math.abs(locTime - calcTs) > 2000) {
 				DEBUG && console.log('[gancube]', 'time adjust', locTime - calcTs, '@', locTime);
 				deviceTime += locTime - calcTs;
 			}
@@ -774,6 +774,7 @@ var GiikerCube = execMain(function() {
 				result = _chrct_v2read.stopNotifications().catch($.noop);
 				_chrct_v2read = null;
 			}
+			deviceName = null;
 			deviceMac = null;
 			prevMoves = [];
 			timeOffs = [];
@@ -781,7 +782,10 @@ var GiikerCube = execMain(function() {
 			curCubie = new mathlib.CubieCube();
 			latestFacelet = mathlib.SOLVED_FACELET;
 			deviceTime = 0;
+			deviceTimeOffset = 0;
+			moveCnt = -1;
 			prevMoveCnt = -1;
+			movesFromLastCheck = 1000;
 			batteryLevel = 100;
 			return result;
 		}

--- a/src/js/timer.js
+++ b/src/js/timer.js
@@ -1661,6 +1661,13 @@ var timer = execMain(function(regListener, regProp, getProp, pretty, ui, pushSig
 		}
 	}
 
+	function giikerEvtCallback(info, event) {
+		if (info == 'disconnect') {
+			DEBUG && console.log("Bluetooth Cube is disconnected");
+			$(document).trigger($.Event('keydown', { which: 27 }));
+		}
+	}
+
 	var resetCondition = "input|phases|preScrT?|isTrainScr|giiOri|useMilli|showDiff|smallADP|giiVRC|col-timer".split('|');
 
 	$(function() {
@@ -1679,6 +1686,7 @@ var timer = execMain(function(regListener, regProp, getProp, pretty, ui, pushSig
 				stackmatTimer.setEnable(value[1]);
 				giikerTimer.setEnable(value[1]);
 				ganSmartTimer.setEnable(value[1]);
+				giikerutil.setEventCallback(giikerEvtCallback);
 			}
 			if (value[0] == 'showAvg') {
 				avgDiv.showAvgDiv(value[1]);

--- a/src/js/tools/bluetoothutil.js
+++ b/src/js/tools/bluetoothutil.js
@@ -245,6 +245,7 @@ var giikerutil = execMain(function(CubieCube) {
 	}
 
 	var callback = $.noop;
+	var evtCallback = $.noop;
 
 	var curRawState = mathlib.SOLVED_FACELET;
 	var curRawCubie = new CubieCube();
@@ -483,10 +484,11 @@ var giikerutil = execMain(function(CubieCube) {
 		updateAlgClick(lastSolveClick, "Pretty", kernel.getConjMoves(curScramble), solve)
 	}
 
-	function evtCallback(info, event) {
+	function giikerEvtCallback(info, event) {
 		if (info == 'disconnect') {
 			logohint.push('Bluetooth disconnected!');
 			renderStatus();
+			return typeof evtCallback == 'function' && evtCallback(info, event);
 		}
 	}
 
@@ -501,6 +503,9 @@ var giikerutil = execMain(function(CubieCube) {
 		solvedStateInv = new CubieCube();
 		moveTsList = [];
 		moveTsStart = 0;
+		scrambleLength = 0;
+		hackedSolvedCubieInv = null;
+		hackedCubie = new CubieCube();
 		slopeTd.html(slopeIcon + '0%');
 		updateAlgClick(algCubingClick, "Raw(N/A)");
 		updateAlgClick(lastSolveClick, "Pretty(N/A)");
@@ -512,7 +517,7 @@ var giikerutil = execMain(function(CubieCube) {
 		curRawCubie.fromFacelet(curRawState);
 		solvedStateInv.invFrom(curRawCubie);
 		GiikerCube.setCallback(giikerCallback);
-		GiikerCube.setEventCallback(evtCallback);
+		GiikerCube.setEventCallback(giikerEvtCallback);
 		if (!GiikerCube.isConnected()) {
 			return GiikerCube.init().then(function () {
 				logohint.push('Bluetooth successfully connected!');
@@ -525,7 +530,7 @@ var giikerutil = execMain(function(CubieCube) {
 	function stop() {
 		if (GiikerCube.isConnected()) {
 			return GiikerCube.stop().then(function () {
-				evtCallback('disconnect');
+				giikerEvtCallback('disconnect');
 			});
 		} else {
 			return Promise.resolve();
@@ -665,6 +670,9 @@ var giikerutil = execMain(function(CubieCube) {
 	return {
 		setCallback: function(func) {
 			callback = func;
+		},
+		setEventCallback: function(func) {
+			evtCallback = func;
 		},
 		markSolved: markSolved,
 		checkScramble: checkScramble,


### PR DESCRIPTION
- Properly initialize all state variables in the GanCube driver to avoid some edge cases that may occur if application is not reloaded each time before cube connection.
- Properly handle timer state upon unexpected cube disconnection. Simply emulate ESC keypress, so if cube suddenly disconnects during solve, just stop timer and record DNF.