### PR TITLE
Improve scrambling UI for Bluetooth cubes

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -738,6 +738,25 @@ div.helptable ul {
 	max-height: 80vh;
 }
 
+#scrambleTxt .smrtScrDim {
+	filter: opacity(50%) blur(1px);
+}
+
+#scrambleTxt .smrtScrMrk {
+	color: #0d0;
+	font-size: 75%;
+}
+
+#scrambleTxt .smrtScrDim,
+#scrambleTxt .smrtScrCur,
+#scrambleTxt .smrtScrAct,
+#scrambleTxt .smrtScrMrk {
+	border-radius: 15% / 30%;
+	padding-left: 0.3em;
+	padding-right: 0.3em;
+	display: inline-block;
+}
+
 #scrambleTxt.limit {
 	max-height: 150px;
 	max-height: 10.5rem;

--- a/src/js/kernel.js
+++ b/src/js/kernel.js
@@ -592,6 +592,7 @@ var kernel = execMain(function() {
 
 		var csstmp =
 			"html,body,textarea,#leftbar{color:?;background-color:?}" +
+			".smrtScrCur{color:?;background-color:?}" +
 			"#leftbar{border-color:?}" +
 			"#logo{color:?;border-color:?;background-color:?}" +
 			".mybutton,.tab,.cntbar{border-color:?}" +
@@ -624,7 +625,7 @@ var kernel = execMain(function() {
 
 		// var cur_color = ["#000", "#efc", "#cda", "#ff0", "#dd0", "#000", "#dbb", "#fdd", "#fbb", "#000", "#dbb", "#00f", "#dbb"];
 		var cur_color = ["#000", "#efc", "#fdd", "#fbb", "#dbb", "#ff0", "#000"];
-		var col_map = [0, 1, 1|0x220, 5, 5|0x220, 6, 2|0x220, 2, 3, 0, 2|0x220, 4, 2|0x220, 1|0x220, 0, 2|0xef0, 2|0x220, 2|0x110, 0];
+		var col_map = [0, 1, 2, 0, 1|0x220, 5, 5|0x220, 6, 2|0x220, 2, 3, 0, 2|0x220, 4, 2|0x220, 1|0x220, 0, 2|0xef0, 2|0x220, 2|0x110, 0];
 		var col_props = ['font', 'back', 'board', 'button', 'link', 'logo', 'logoback'];
 
 		function useColorTemplate(value) {

--- a/src/js/scramble/scramble.js
+++ b/src/js/scramble/scramble.js
@@ -237,7 +237,7 @@ var scramble = execMain(function(rn, rndEl) {
 			len = ~~m[2];
 		}
 		if (forDisplay) {
-			var scrTxtLen = scramble.replace(/~/g, '').replace(/\\n/g, '\n').replace(/`([^`]*)`/g, '$1').length;
+			var scrTxtLen = scramble.replace(/<[^>]*>/g, '').replace(/~/g, '').replace(/\\n/g, '\n').replace(/`([^`]*)`/g, '$1').length;
 			var fontSize = kernel.getProp('scrASize') ? Math.max(0.25, Math.round(Math.pow(50 / Math.max(scrTxtLen, 10), 0.30) * 20) / 20) : 1;
 			sdiv.css('font-size', fontSize + 'em');
 			DEBUG && console.log('[scrFontSize]', fontSize);

--- a/src/js/tools/bluetoothutil.js
+++ b/src/js/tools/bluetoothutil.js
@@ -64,12 +64,11 @@ var scrHinter = execMain(function(CubieCube) {
 			if (next == 0 && i == 0) {
 				m = [m[0], m[1], (m[2] - pow + 7) % 4];
 			}
-			ret.push((i == next ? '`' : '') + 'URFDLB'.charAt(m[0]) + [null, "", "2", "'"][m[2]]);
+			if (i == next) ret.push(':');
+			ret.push('URFDLB'.charAt(m[0]) + [null, "", "2", "'"][m[2]]);
+			if (i == next) ret.push(':');
 		}
 		ret = ret.join(' ');
-		if (next != seq.length) {
-			ret += '`';
-		}
 		ret = kernel.getConjMoves(ret, true);
 		return ret;
 	}
@@ -84,7 +83,7 @@ var scrHinter = execMain(function(CubieCube) {
 		if (genState) {
 			toMoveFix = checkInSeq(state, genState, genScr);
 		}
-		if (toMoveFix == null || toMoveFix.indexOf('`') == -1) {
+		if (toMoveFix == null || toMoveFix.indexOf(':') == -1) {
 			toMoveRaw = checkInSeq(state, null, rawScr);
 			genState = null;
 			toMoveFix = null;
@@ -101,8 +100,27 @@ var scrHinter = execMain(function(CubieCube) {
 			genScr = kernel.parseScramble(genScr, "URFDLB");
 			toMoveFix = checkInSeq(state, genState, genScr);
 		}
-		var toMove = toMoveFix ? (rawScrTxt + '\n=> ' + toMoveFix) : toMoveRaw;
-		kernel.pushSignal('scrfix', toMove + (toMove.indexOf('`') == -1 ? ' <span style="color:green">\u2714</span>' : ''));
+		var toMove = toMoveFix ? scrambleToHtml(toMoveFix) : scrambleToHtml(toMoveRaw);
+		kernel.pushSignal('scrfix', toMove);
+	}
+
+	function scramblePartToHtml(part, cssClass) {
+		return part && $.map(part.split(' '), function (move) { return move && ("<span class='" + cssClass + "'>" + move.trim() + "</span>") }).join('');
+	}
+
+	function scrambleToHtml(scrTxt) {
+		var scrHtml = "";
+		var isScrambled = scrTxt.indexOf(':') == -1;
+		var scrParts = $.map(scrTxt.split(':', 3), function (part) { return part.trim() });
+		if (isScrambled) {
+			scrHtml += scramblePartToHtml(scrParts[0], 'smrtScrAct');
+			scrHtml += "<span class='smrtScrMrk'>&#x2713;</span>";
+		} else {
+			scrHtml += scramblePartToHtml(scrParts[0], 'smrtScrDim');
+			scrHtml += scramblePartToHtml(scrParts[1], 'smrtScrCur');
+			scrHtml += scramblePartToHtml(scrParts[2], 'smrtScrAct');
+		}
+		return scrHtml;
 	}
 
 	function checkScramble(curCubie) {


### PR DESCRIPTION
Scramble UI for Bluetooth cubes wasn't so convenient.
Especially that '=>' scramble fix appearing under original scramble, it looks very confusing for users.

Just made this scrambling UI to look and feel more clear and understandable.

Approach used to enclose each scramble letter to individual `span` with `inline-block` display type is required to have ability to set desired paddings to scramble letters. At the same time to avoid flickering when current move "cursor" passes through scramble. When "cursor" moves scramble letters are alway fixed in place and does not flick. This makes tracking "cursor" movement with your eyes much easier and more comfortable. 

https://github.com/cs0x7f/cstimer/assets/4266693/a3b2735e-18b9-4dfc-adee-0df0e23ca549

