### PR TITLE
Improve a11y for mobile touchscreen devices

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -817,8 +817,8 @@ div.helptable ul {
 .dialogcfm {
 	left: 30%;
 	right: 30%;
-	top: 30%;
-	bottom: 30%;
+	top: 25%;
+	bottom: 25%;
 }
 
 .dialoginput, .dialogstats, .dialogexport, .dialogscropt {
@@ -1155,8 +1155,8 @@ html.m .mhide, html:not(.m) .mshow {
 }
 
 .m .dialogcfm {
-	left: 15%;
-	right: 15%;
+	left: 10%;
+	right: 10%;
 	top: 25%;
 	bottom: 25%;
 }
@@ -1275,4 +1275,49 @@ html.m .mhide, html:not(.m) .mshow {
 	margin: 1em;
 	padding-left: 1.5em;
 	list-style: disc;
+}
+
+.cfmPrettyMPA {
+	width: 100%;
+	text-align: center;
+	padding-bottom: 0.5em;
+}
+
+.cfmButtons {
+	margin: 0px;
+	padding: 0px;
+	width: 100%;
+	text-align: center;
+}
+
+.cfmButtons input[type="button"] {
+	margin: 0em 0.25em 0em 0.25em;
+	padding: 0.25em 1em 0.25em 1em;
+}
+
+.cfmTable {
+	width: 100%;
+	margin: 0.5em 0em 0.5em 0em;
+}
+
+.cfmTable td:nth-of-type(1) {
+	text-align: right;
+	width: 25%;
+	text-transform: capitalize;
+}
+
+.cfmTable td:nth-of-type(1)::after {
+	content: ':';
+}
+
+.cfmTable td:nth-of-type(2) {
+	text-align: left;
+	width: 75%;
+}
+
+.cfmTable input[type="text"] {
+	width: 90%;
+	text-align: left;
+	padding: 0.2em;
+	margin-left: 0.5em;
 }

--- a/src/js/stats/stats.js
+++ b/src/js/stats/stats.js
@@ -346,11 +346,14 @@ var stats = execMain(function(kpretty, round, kpround) {
 	var floatCfm = (function() {
 		var cfmDiv = $('<div style="text-align:center; font-family: initial;">');
 		var cfmTime = $('<span style="font-size:2.5em;"/>');
-		var cfmTxtR = $('<input type="text">').css('width', '8em');
-		var cfmDelR = $('<input type="button" data="d">').val("X");
-		var cfmScrR = $('<input type="text" readonly>').css('width', '8em');
-		var cfmDate = $('<input type="text" readonly>').css('width', '8em');
-		var cfmExt = $('<input type="text" readonly>').css('width', '8em');
+		var cfmTxtR = $('<input type="text">');
+		var cfmOkR = $('<input type="button" data="ok">').val("OK");
+		var cfmPenR = $('<input type="button" data="pen">').val("+2");
+		var cfmDnfR = $('<input type="button" data="dnf">').val("DNF");
+		var cfmDelR = $('<input type="button" data="del">').val("X");
+		var cfmScrR = $('<input type="text" readonly>');
+		var cfmDate = $('<input type="text" readonly>');
+		var cfmExt = $('<input type="text" readonly>');
 
 		var cfmIdx = 0;
 		var cfmIdxRow;
@@ -382,10 +385,13 @@ var stats = execMain(function(kpretty, round, kpround) {
 			if (!which) {
 				return;
 			}
-			if (which == 'p') {
-				var selected = {" OK ": 0, " +2 ": 2000, " DNF ": -1}[target.html()];
-				setPenalty(selected, cfmIdx);
-			} else if (which == 'd') {
+			if (which == 'ok') {
+				setPenalty(0, cfmIdx);
+			} else if (which == 'pen') {
+				setPenalty(2000, cfmIdx);
+			} else if (which == 'dnf') {
+				setPenalty(-1, cfmIdx);
+			} else if (which == 'del') {
 				if (delIdx(cfmIdx)) {
 					cfmIdx = undefined;
 					hideToTools();
@@ -437,18 +443,16 @@ var stats = execMain(function(kpretty, round, kpround) {
 			var time = timesAt(cfmIdx);
 			var reviewElem = '';
 			if (time[4]) {
-				// reviewElem = $('<a target="_blank">' + STATS_REVIEW + '</a>').addClass('click');
-				// reviewElem.attr('href', getReviewUrl(time));
 				reviewElem = $('<span class="click" data="r">' + STATS_REVIEW + '</span>');
 				reviewElem = $('<tr>').append($('<td>').append(reviewElem), $('<td>').append(cfmExt));
 			}
-			cfmDiv.empty().append(cfmTime, '<br>', prettyMPA(time[0]), '<br>')
-				.append('<span class="click" data="c"> &#128203; </span>|<span class="click" data="p"> OK </span>|<span class="click" data="p"> +2 </span>|<span class="click" data="p"> DNF </span>| ', cfmDelR)
-				.append('<br>', $('<table style="display:inline-block;">').append(
-					$('<tr>').append('<td>' + STATS_COMMENT + '</td>', $('<td>').append(cfmTxtR)),
+			cfmDiv.empty().append(cfmTime.addClass('click').attr('data', 'c'), $('<div>').addClass('cfmPrettyMPA').append(prettyMPA(time[0])))
+				.append($('<div>').addClass('cfmButtons').append(cfmOkR, cfmPenR, cfmDnfR, cfmDelR))
+				.append($('<table>').addClass('cfmTable').append(
 					$('<tr>').append('<td><span class="click" data="s">' + SCRAMBLE_SCRAMBLE + '</span></td>', $('<td>').append(cfmScrR)),
 					$('<tr>').append('<td>' + STATS_DATE + '</td>', $('<td>').append(cfmDate)),
-					reviewElem
+					reviewElem,
+					$('<tr>').append('<td>' + STATS_COMMENT + '</td>', $('<td>').append(cfmTxtR)),
 				)).unbind('click').click(procClk);
 			cfmTime.html(pretty(time[0], true));
 			cfmScrR.val(time[1]);
@@ -473,7 +477,7 @@ var stats = execMain(function(kpretty, round, kpround) {
 					kernel.pushSignal('reqrec', [timesAt(idx), idx]);
 				}]);
 			}
-			kernel.showDialog(params, 'cfm', 'Solves No.' + (idx + 1));
+			kernel.showDialog(params, 'cfm', 'Solve No.' + (idx + 1));
 		}
 
 		function setPenalty(value, idx) {
@@ -1709,6 +1713,10 @@ var stats = execMain(function(kpretty, round, kpround) {
 				floatCfm.setCfm(2000);
 			} else if (value[1] == 'DNF') {
 				floatCfm.setCfm(-1);
+			} else if (value[1] == 'showlast') {
+				if (times.length > 0) {
+					floatCfm.proc(times.length - 1, kernel.getProp('statinv') ? avgRow.prev() : title.next());
+				}
 			}
 		} else if (signal == 'ashow' && !value) {
 			table_ctrl.hideAll();

--- a/src/js/timer.js
+++ b/src/js/timer.js
@@ -1692,7 +1692,7 @@ var timer = execMain(function(regListener, regProp, getProp, pretty, ui, pushSig
 				avgDiv.showAvgDiv(value[1]);
 			}
 			if (value[0] == 'giiVRC' && value[2] != 'set') {
-				giikerTimer.setEnable(getProp('input'));
+				giikerTimer.setVRC(getProp('input') == 'g' && value[1] != 'n');
 			}
 			if (['toolPos', 'scrHide', 'toolHide', 'statHide'].indexOf(value[0]) >= 0) {
 				updateTimerOffsetAsync(false);

--- a/src/js/timer.js
+++ b/src/js/timer.js
@@ -1603,6 +1603,14 @@ var timer = execMain(function(regListener, regProp, getProp, pretty, ui, pushSig
 		if (status == -1 && keyCode == 27) {
 			lcd.renderUtil(true);
 		}
+		// handle swipe gestures but only for specific timers
+		if ("sbig".indexOf(getProp('input')) >= 0) {
+			if (keyCode == 140 && status == -1) { // swipe left
+				kernel.pushSignal('ctrl', ['stats', 'undo']);
+			} else if (keyCode == 142 && status == -1) { // swipe up
+				kernel.pushSignal('ctrl', ['stats', 'showlast']);
+			}
+		}
 		switch (getProp('input')) {
 			case 't':
 			case 'l':


### PR DESCRIPTION
Since touchscreen mobile devices has no keyboard, and keyboard shortcuts can't be used there, here are some improvements which makes solving workflow much more handy on such devices.

- Added recognition of basic swipe gestures to the kernel.
- For certain timers (for which it is suitable) bind `Swipe Left` gesture to the Undo action deleting last solve, and bind `Swipe Up` gesture to the action which opens dialog with last solve.
- Rework of dialog showing solve information to be more handy and usable on mobile devices with touchscreen. Old buttons are barely accessible especially on small screen smartphone devices.

<img src="https://github.com/cs0x7f/cstimer/assets/4266693/01bb512a-f400-4a56-9412-206f400d847b" width="500px">
