### PR TITLE
Fix handling of changes in giiVRC property

### DIFF
--- a/src/js/timer.js
+++ b/src/js/timer.js
@@ -1695,7 +1695,7 @@ var timer = execMain(function(regListener, regProp, getProp, pretty, ui, pushSig
 				avgDiv.showAvgDiv(value[1]);
 			}
 			if (value[0] == 'giiVRC' && value[2] != 'set') {
-				giikerTimer.setEnable(getProp('input'));
+				giikerTimer.setVRC(getProp('input') == 'g' && value[1] != 'n');
 			}
 			if (['toolPos', 'scrHide', 'toolHide', 'statHide'].indexOf(value[0]) >= 0) {
 				updateTimerOffsetAsync(false);


### PR DESCRIPTION
That missing commit from previous PR.
Fix for minor issue which occurs when switching sessions, and that sessions has own local and different `giiVRC` property value set. When switching sessions, property change events are fired in sequence, and `giiVRC` property change is fired before `input`. This leads to one more early unnecessary call to `giikerTimer.setEnable()` which results in bluetooth cube connection dialog popup even if session is configured to use different time source.