### PR TITLE
Better fix for scramble copying

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -796,8 +796,6 @@ div.helptable ul {
 	border-radius: 15% / 30%;
 	padding-left: 0.3em;
 	padding-right: 0.3em;
-	margin-left: -0.3em;
-	margin-right: -0.3em;
 	display: inline-block;
 }
 

--- a/src/js/scramble/scramble.js
+++ b/src/js/scramble/scramble.js
@@ -219,7 +219,9 @@ var scramble = execMain(function(rn, rndEl) {
 		}
 		var act = kernel.getProp('scrClk', 'n');
 		if (act == 'c') {
-			var succ = $.clipboardCopy(sdiv.text());
+			var scrTxt = (tools.getCurScramble()[1]).trim();
+			var succ = $.clipboardCopy(scrTxt);
+			DEBUG && console.log('[scramble]', 'Copy to clipboard, scrTxt = "' + scrTxt + '", success = ' + succ);
 			if (succ) {
 				logohint.push(LGHINT_SCRCOPY);
 			}
@@ -238,14 +240,14 @@ var scramble = execMain(function(rn, rndEl) {
 			len = ~~m[2];
 		}
 		if (forDisplay) {
-			var scrTxtLen = scramble.replace(/<[^>]*>/g, '').replace(/~/g, '').replace(/\\n/g, '\n').replace(/`([^`]*)`/g, '$1').length;
+			var scrTxtLen = scramble.replace(/<span[^>]*>(.*?)<\/span>/ig, '$1 ').replace(/~/g, '').replace(/\\n/g, '\n').replace(/`([^`]*)`/g, '$1').length;
 			var fontSize = kernel.getProp('scrASize') ? Math.max(0.25, Math.round(Math.pow(50 / Math.max(scrTxtLen, 10), 0.30) * 20) / 20) : 1;
 			sdiv.css('font-size', fontSize + 'em');
 			DEBUG && console.log('[scrFontSize]', fontSize);
 			return scramble.replace(/~/g, '&nbsp;').replace(/\\n/g, '\n')
 				.replace(/`([^`]*)`/g, forceKeyM || kernel.getProp('scrKeyM', false) ? '<u>$1</u>' : '$1');
 		} else {
-			return [type, scramble.replace(/~/g, '').replace(/\\n/g, '\n').replace(/`([^`]*)`/g, '$1'), len];
+			return [type, scramble.replace(/<span[^>]*>(.*?)<\/span>/ig, '$1 ').replace(/~/g, '').replace(/\\n/g, '\n').replace(/`([^`]*)`/g, '$1'), len];
 		}
 	}
 

--- a/src/js/tools/bluetoothutil.js
+++ b/src/js/tools/bluetoothutil.js
@@ -120,7 +120,7 @@ var scrHinter = execMain(function(CubieCube) {
 			scrHtml += scramblePartToHtml(scrParts[1], 'smrtScrCur');
 			scrHtml += scramblePartToHtml(scrParts[2], 'smrtScrAct');
 		}
-		return scrHtml.replace(/span><span/g, 'span> <span');
+		return scrHtml;
 	}
 
 	function checkScramble(curCubie) {


### PR DESCRIPTION
Previous commit with fix for scramble copying fd9484e8f0fd0dca29b0d2092f11f55f0178e024 breaks proper scramble visualization when non-monospace font is enabled, or if scramble is aligned to the left or right. Actually it is better to not touch such markup without great necessity, I've put some effort into making it look good in all modes and do not flicker or jump, and make it comfortable to follow by eyes during scrambling.

Initially I've made following for properly retrieve scramble text for copy:

```javascript
var scrTxt = $('<div>').append(
	sdiv.html().replace(/<span[^>]*>(.*?)<\/span>/g, '$1 ')
).text().trim();
```
But then I realize that such behavior maybe not correct in case of smartcubes. Since existing copy to clipboard code just get scramble text currently displayed in div. But in smartcube mode there can be not current scramble, but scramble fix which display only partial moves from current state. So it is better to not rely on such div contents, but just get currently active scramble text from proper source.

BTW, the [execCommand](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand) API used in the `$.clipboardCopy()` is deprecated, and may be removed in the future. So at some point it is better to migrate to the [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API).

