### PR TITLE
Bluetooth cube improvements

### DIFF
--- a/src/js/bluetooth.js
+++ b/src/js/bluetooth.js
@@ -136,8 +136,7 @@ var GiikerCube = execMain(function() {
 				console.log('[giiker]', "Raw Data: ", valhex.join(""));
 				console.log('[giiker]', "Current State: ", facelet);
 				console.log('[giiker]', "A Valid Generator: ", scramble_333.genFacelet(facelet));
-				console.log('[giiker]', "Previous Moves: ", prevMoves.reverse().join(" "));
-				prevMoves.reverse();
+				console.log('[giiker]', "Previous Moves: ", prevMoves.slice().reverse().join(" "));
 			}
 			callback(facelet, prevMoves, [locTime, locTime], deviceName);
 			return [facelet, prevMoves];
@@ -622,7 +621,7 @@ var GiikerCube = execMain(function() {
 		function initCubeState() {
 			var locTime = $.now();
 			DEBUG && console.log('[gancube]', 'init cube state');
-			callback(latestFacelet, prevMoves, [null, locTime], deviceName);
+			callback(latestFacelet, [], [null, locTime], deviceName);
 			prevCubie.fromFacelet(latestFacelet);
 			prevMoveCnt = moveCnt;
 			if (latestFacelet != kernel.getProp('giiSolved', mathlib.SOLVED_FACELET)) {
@@ -1062,6 +1061,7 @@ var GiikerCube = execMain(function() {
 		var curFacelet = mathlib.SOLVED_FACELET;
 		var curCubie = new mathlib.CubieCube();
 		var prevCubie = new mathlib.CubieCube();
+		var prevMoves = [];
 
 		function parseData(value) {
 			var locTime = $.now();
@@ -1085,7 +1085,10 @@ var GiikerCube = execMain(function() {
 					mathlib.CubieCube.EdgeMult(prevCubie, mathlib.CubieCube.moveCube[m], curCubie);
 					mathlib.CubieCube.CornMult(prevCubie, mathlib.CubieCube.moveCube[m], curCubie);
 					curFacelet = curCubie.toFaceCube();
-					callback(curFacelet, ["URFDLB".charAt(axis) + " 2'".charAt(power)], [locTime, locTime], _deviceName);
+					prevMoves.unshift("URFDLB".charAt(axis) + " 2'".charAt(power));
+					if (prevMoves.length > 8)
+						prevMoves = prevMoves.slice(0, 8);
+					callback(curFacelet, prevMoves, [locTime, locTime], _deviceName);
 					var tmp = curCubie;
 					curCubie = prevCubie;
 					prevCubie = tmp;
@@ -1144,6 +1147,11 @@ var GiikerCube = execMain(function() {
 			_service = null;
 			_gatt = null;
 			_deviceName = null;
+			moveCntFree = 100;
+			curFacelet = mathlib.SOLVED_FACELET;
+			curCubie = new mathlib.CubieCube();
+			prevCubie = new mathlib.CubieCube();
+			prevMoves = [];
 			return result;
 		}
 
@@ -1208,7 +1216,7 @@ var GiikerCube = execMain(function() {
 		var curFacelet = mathlib.SOLVED_FACELET;
 		var curCubie = new mathlib.CubieCube();
 		var prevCubie = new mathlib.CubieCube();
-		var timeOffset = 0;
+		var prevMoves = [];
 
 		function onReadEvent(event) {
 			var value = event.target.value;
@@ -1256,17 +1264,15 @@ var GiikerCube = execMain(function() {
 				} else {
 					continue;
 				}
-				var calcTs = ts + timeOffset;
-				// if (timeOffset == 0 || Math.abs(locTime - calcTs) > 2000 || timer.getStatus() == -1 && Math.abs(locTime - calcTs) > 300) {
-				// 	timeOffset = locTime - ts;
-				// 	calcTs = locTime;
-				// }
 				var m = axis * 3 + pow;
 				DEBUG && console.log('[moyucube]', 'move', "URFDLB".charAt(axis) + " 2'".charAt(pow));
 				mathlib.CubieCube.EdgeMult(prevCubie, mathlib.CubieCube.moveCube[m], curCubie);
 				mathlib.CubieCube.CornMult(prevCubie, mathlib.CubieCube.moveCube[m], curCubie);
 				curFacelet = curCubie.toFaceCube();
-				callback(curFacelet, ["URFDLB".charAt(axis) + " 2'".charAt(pow)], [calcTs, locTime], _deviceName);
+				prevMoves.unshift("URFDLB".charAt(axis) + " 2'".charAt(pow));
+				if (prevMoves.length > 8)
+					prevMoves = prevMoves.slice(0, 8);
+				callback(curFacelet, prevMoves, [ts, locTime], _deviceName);
 				var tmp = curCubie;
 				curCubie = prevCubie;
 				prevCubie = tmp;
@@ -1299,6 +1305,11 @@ var GiikerCube = execMain(function() {
 			_service = null;
 			_gatt = null;
 			_deviceName = null;
+			faceStatus = [0, 0, 0, 0, 0, 0];
+			curFacelet = mathlib.SOLVED_FACELET;
+			curCubie = new mathlib.CubieCube();
+			prevCubie = new mathlib.CubieCube();
+			prevMoves = [];
 			return result;
 		}
 

--- a/src/js/bluetooth.js
+++ b/src/js/bluetooth.js
@@ -607,6 +607,7 @@ var GiikerCube = execMain(function() {
 
 		var prevMoves = [];
 		var timeOffs = [];
+		var moveBuffer = []; // [ [moveCnt, move, ts, locTime], ... ]
 		var prevCubie = new mathlib.CubieCube();
 		var curCubie = new mathlib.CubieCube();
 		var latestFacelet = mathlib.SOLVED_FACELET;
@@ -616,7 +617,6 @@ var GiikerCube = execMain(function() {
 		var prevMoveCnt = -1;
 		var movesFromLastCheck = 1000;
 		var batteryLevel = 100;
-		var lastV3ts = -1;
 
 		function initCubeState() {
 			var locTime = $.now();
@@ -855,6 +855,78 @@ var GiikerCube = execMain(function() {
 
 		$.parseV2Data = parseV2Data; // for debug
 
+		// Check if circular move number (modulo 256) fits into (start,end) range exclusive.
+		function isMoveNumberInRange(start, end, moveCnt) {
+			return ((end - start) & 0xFF) > ((moveCnt - start) & 0xFF)
+				&& ((start - moveCnt) & 0xFF) > 0
+				&& ((end - moveCnt) & 0xFF) > 0;
+		}
+
+		function v3InjectLostMoveToBuffer(move) {
+			if (moveBuffer.length > 0) {
+				// Skip if move with the same number already in the buffer
+				if (moveBuffer.some(function (e) { return e[0] == move[0] }))
+					return;
+				// Skip if move number does not fit in range between last evicted move number and move number on buffer head, i.e. move must be one of missed
+				if (!isMoveNumberInRange(prevMoveCnt, moveBuffer[0][0], move[0]))
+					return;
+				// Lost moves should be injected in reverse order, so just put suitable move on buffer head
+				if (move[0] == ((moveBuffer[0][0] - 1) & 0xFF)) {
+					move[2] = moveBuffer[0][2] - 10; // Set lost move device hardware timestamp near to next move event
+					moveBuffer.unshift(move);
+					DEBUG && console.log('[gancube]', 'v3 lost move recovered', move[0], move[1]);
+				}
+			}
+		}
+
+		function v3requestMoveHistory(startMoveCnt, numberOfMoves) {
+			var req = mathlib.valuedArray(16, 0);
+			// Move history response data is byte-aligned, and moves always starting with near-ceil odd serial number, regardless of requested.
+			// Adjust serial and count to always get properly aligned history window that contains all reqested moves.
+			if (startMoveCnt % 2 == 0) {
+				startMoveCnt = (startMoveCnt + 1) & 0xFF;
+				numberOfMoves += numberOfMoves % 2 == 0 ? 2 : 1;
+			}
+			req[0] = 0x68;
+			req[1] = 0x03;
+			req[2] = startMoveCnt;
+			req[3] = 0;
+			req[4] = numberOfMoves;
+			req[5] = 0;
+			// We can safely suppress and ignore possible GATT write errors, v3requestMoveHistory command is automatically retried on each move event if needed
+			return v3sendRequest(req).catch($.noop);
+		}
+
+		function v3EvictMoveBuffer(reqLostMoves) {
+			while (moveBuffer.length > 0) {
+				var diff = (moveBuffer[0][0] - prevMoveCnt) & 0xFF;
+				if (diff > 1) {
+					DEBUG && console.log('[gancube]', 'v3 lost move detected', prevMoveCnt, moveBuffer[0][0], diff);
+					if (reqLostMoves) {
+						v3requestMoveHistory(moveBuffer[0][0], diff);
+					}
+					break;
+				} else {
+					var move = moveBuffer.shift();
+					var m = "URFDLB".indexOf(move[1][0]) * 3 + " 2'".indexOf(move[1][1]);
+					mathlib.CubieCube.EdgeMult(prevCubie, mathlib.CubieCube.moveCube[m], curCubie);
+					mathlib.CubieCube.CornMult(prevCubie, mathlib.CubieCube.moveCube[m], curCubie);
+					prevMoves.unshift(move[1]);
+					if (prevMoves.length > 8)
+						prevMoves = prevMoves.slice(0, 8);
+					callback(curCubie.toFaceCube(), prevMoves, [move[2], move[3]], deviceName + '*');
+					var tmp = curCubie;
+					curCubie = prevCubie;
+					prevCubie = tmp;
+					prevMoveCnt = move[0];
+					DEBUG && console.log('[gancube]', 'v3 move evicted from fifo buffer', move[0], move[1], move[2], move[3]);
+				}
+			}
+			if (moveBuffer.length > 32) { // Something wrong, moves are not evicted from buffer, force cube disconnection
+				onDisconnect();
+			}
+		}
+
 		function onStateChangedV3(event) {
 			var value = event.target.value;
 			if (decoder == null) {
@@ -865,47 +937,40 @@ var GiikerCube = execMain(function() {
 
 		function parseV3Data(value) {
 			var locTime = $.now();
-			DEBUG && console.log('[gancube]', 'dec v3', value);
+			DEBUG && console.log('[gancube]', 'v3 raw message', value);
 			value = decode(value);
 			for (var i = 0; i < value.length; i++) {
 				value[i] = (value[i] + 256).toString(2).slice(1);
 			}
 			value = value.join('');
-			DEBUG && console.log('[gancube]', 'dec v3 decrypted', value);
+			DEBUG && console.log('[gancube]', 'v3 decrypted message', value);
 			var magic = parseInt(value.slice(0, 8), 2);
 			var mode = parseInt(value.slice(8, 16), 2);
 			var len = parseInt(value.slice(16, 24), 2);
 			if (magic != 0x55 || len <= 0) {
-				DEBUG && console.log('[gancube]', 'invalid magic or len', value);
+				DEBUG && console.log('[gancube]', 'v3 invalid magic or len', value);
 				return;
 			}
 			if (mode == 1) { // cube move
 				DEBUG && console.log('[gancube]', 'v3 received move event', value);
 				moveCnt = parseInt(value.slice(64, 72) + value.slice(56, 64), 2);
-				if (moveCnt == prevMoveCnt) {
-					return;
-				} else if (prevMoveCnt == -1) {
-					prevMoveCnt = moveCnt;
+				if (moveCnt == prevMoveCnt || prevMoveCnt == -1) {
 					return;
 				}
-				var v3ts = parseInt(value.slice(48, 56) + value.slice(40, 48) + value.slice(32, 40) + value.slice(24, 32), 2);
+				var ts = parseInt(value.slice(48, 56) + value.slice(40, 48) + value.slice(32, 40) + value.slice(24, 32), 2);
 				var pow = parseInt(value.slice(72, 74), 2);
-				var axis = parseInt(value.slice(74, 80), 2);
-				axis = [2, 32, 8, 1, 16, 4].indexOf(axis);
+				var axis = [2, 32, 8, 1, 16, 4].indexOf(parseInt(value.slice(74, 80), 2));
 				if (axis == -1) {
-					console.log('[gancube]', 'v3 move event invalid axis', value);
+					DEBUG && console.log('[gancube]', 'v3 move event invalid axis');
 					return;
 				}
-				timeOffs = [lastV3ts == -1 ? 0 : ((v3ts - lastV3ts) & 0xffffffff)];
-				prevMoves = ["URFDLB".charAt(axis) + " '".charAt(pow)];
-				lastV3ts = v3ts;
-				updateMoveTimes(locTime, 1);
+				var move = "URFDLB".charAt(axis) + " '".charAt(pow);
+				moveBuffer.push([moveCnt, move, ts, locTime]);
+				DEBUG && console.log('[gancube]', 'v3 move placed to fifo buffer', moveCnt, move, ts, locTime);
+				v3EvictMoveBuffer(true);
 			} else if (mode == 2) {  // cube state
 				DEBUG && console.log('[gancube]', 'v3 received facelets event', value);
 				moveCnt = parseInt(value.slice(32, 40) + value.slice(24, 32), 2);
-				if (moveCnt != prevMoveCnt && prevMoveCnt != -1) {
-					return;
-				}
 				var cc = new mathlib.CubieCube();
 				var echk = 0;
 				var cchk = 0xf00;
@@ -926,19 +991,27 @@ var GiikerCube = execMain(function() {
 				cc.ea[11] = echk;
 				if (cc.verify() != 0) {
 					keyCheck++;
+					DEBUG && console.log('[gancube]', 'v3 facelets state verify error');
 					return;
 				}
 				latestFacelet = cc.toFaceCube();
+				DEBUG && console.log('[gancube]', 'v3 facelets event state parsed', latestFacelet);
 				if (prevMoveCnt == -1) {
 					initCubeState();
-				} else if (prevCubie.toFaceCube() != latestFacelet) {
-					DEBUG && console.log('[gancube]', 'Cube state check error');
-					DEBUG && console.log('[gancube]', 'calc', prevCubie.toFaceCube());
-					DEBUG && console.log('[gancube]', 'read', latestFacelet);
-					prevCubie.fromFacelet(latestFacelet);
-					callback(latestFacelet, prevMoves, [null, locTime], deviceName + '*');
 				}
-				prevMoveCnt = moveCnt;
+			} else if (mode == 6) { // move history
+				DEBUG && console.log('[gancube]', 'v3 received move history event', value);
+				let startMoveCnt = parseInt(value.slice(24, 32), 2);
+				let numberOfMoves = (len - 1) * 2;
+				for (var i = 0; i < numberOfMoves; i++) {
+					var axis = parseInt(value.slice(32 + 4 * i, 35 + 4 * i), 2);
+					var pow = parseInt(value.slice(35 + 4 * i, 36 + 4 * i), 2);
+					if (axis < 6) {
+						var move = "DUBFLR".charAt(axis) + " '".charAt(pow);
+						v3InjectLostMoveToBuffer([(startMoveCnt - i) & 0xFF, move, null, null]);
+					}
+				}
+				v3EvictMoveBuffer(false);
 			} else if (mode == 7) { // hardware info
 				DEBUG && console.log('[gancube]', 'v3 received hardware info event', value);
 				var hardwareVersion = parseInt(value.slice(80, 84), 2) + "." + parseInt(value.slice(84, 88), 2);
@@ -981,6 +1054,7 @@ var GiikerCube = execMain(function() {
 			deviceMac = null;
 			prevMoves = [];
 			timeOffs = [];
+			moveBuffer = [];
 			prevCubie = new mathlib.CubieCube();
 			curCubie = new mathlib.CubieCube();
 			latestFacelet = mathlib.SOLVED_FACELET;

--- a/src/js/timer.js
+++ b/src/js/timer.js
@@ -1408,7 +1408,8 @@ var timer = execMain(function(regListener, regProp, getProp, pretty, ui, pushSig
 				lcd.fixDisplay(false, true);
 			}
 			if (status >= 1) {
-				rawMoves[status - 1].push([prevMoves[0], lastTs[0], lastTs[1]]);
+				if (prevMoves.length > 0)
+					rawMoves[status - 1].push([prevMoves[0], lastTs[0], lastTs[1]]);
 				var curProgress = cubeutil.getProgress(facelet, solvingMethod);
 				updateMulPhase(totPhases, curProgress, locTime);
 

--- a/src/js/tools/bluetoothutil.js
+++ b/src/js/tools/bluetoothutil.js
@@ -360,7 +360,7 @@ var giikerutil = execMain(function(CubieCube) {
 		moveTsStart = moveTsList.length;
 		scrambleLength = 0;
 		drawState();
-		callback(curState, ['U '], [null, $.now()]);
+		callback(curState, [], [null, $.now()]);
 	}
 
 	var moveTsList = []; //[[move, deviceTime, locTime], ...], locTime might be null
@@ -654,7 +654,7 @@ var giikerutil = execMain(function(CubieCube) {
 			CubieCube.EdgeMult(targetCubie, hackedCubie, hackedSolvedCubieInv);
 			CubieCube.CornMult(targetCubie, hackedCubie, hackedSolvedCubieInv);
 			moveTsStart = moveTsList.length;
-			callback(targetCubie.toFaceCube(), ['U '], [null, $.now()]);
+			callback(targetCubie.toFaceCube(), [], [null, $.now()]);
 		}
 		scrambleLength = moveTsList.length - moveTsStart;
 		updateRawMovesClick();
@@ -673,7 +673,7 @@ var giikerutil = execMain(function(CubieCube) {
 			return;
 		}
 		hackedSolvedCubieInv = null;
-		callback(curState, ['U '], [null, $.now()]);
+		callback(curState, [], [null, $.now()]);
 	}
 
 	$(function() {


### PR DESCRIPTION
1. Fix issue with GoCube and MoYuCube drivers. They does not propagate list of prevMoves, only last single move was propagated. So timer functionality like "Mark scrambled by doing" does not work as expected with these cubes.

2. Improve GAN ver3 protocol handling for iCarry2 regarding lost move recovery.

3. Improve GAN ver1 and ver2 protocol handling regarding cube facelets events. Actually this event should not be used in any way expect for initializing cube state upon cube connection. Further due to protocol flaws it is better to not use these events for cube state update. Actual cube state is tracked by csTimer software, and missed moves are recovered using appropriate protocol procedure. Checking for cube state is redundant in general. These events are delivered in async way, and there is no guarantee that they come after move event with same serial being received and processed, so by handling these events directly it is possible to lose moves.
     - GAN 12ui and iCarry cubes does not send these events at all. Only first event upon cube connection is sent.
     - GAN i3 and MoYu AI 2023 cubes may send this event only after grace delay of 500ms after last move made.
     - GAN iCarry2 send this event once per 1000ms, in totally async fashion, so it is high probability this event may come before move event with same serial number.

