### PR TITLE
Update CIC list to include all possible values for GAN cubes

### DIFF
--- a/src/js/bluetooth.js
+++ b/src/js/bluetooth.js
@@ -227,7 +227,8 @@ var GiikerCube = execMain(function() {
 		var CHRCT_UUID_V3READ = '8653000b-43e6-47b7-9cb0-5fc21d4ae340';
 		var CHRCT_UUID_V3WRITE = '8653000c-43e6-47b7-9cb0-5fc21d4ae340';
 
-		var GAN_CIC_LIST = [0x0001, 0x1001, 0x0501]; // List of Company Identifier Codes seen for GAN cubes
+		// List of Company Identifier Codes, fill with all values range [0x0001, 0xFF01] possible for GAN cubes
+		var GAN_CIC_LIST = mathlib.valuedArray(256, function (i) { return (i << 8) | 0x01 });
 
 		var decoder = null;
 		var deviceName = null;
@@ -392,7 +393,7 @@ var GiikerCube = execMain(function() {
 					_device && _device.removeEventListener('advertisementreceived', onAdvEvent);
 					abortController.abort();
 					reject(-2);
-				}, 5000);
+				}, 10000);
 			});
 		}
 

--- a/src/js/lib/mathlib.js
+++ b/src/js/lib/mathlib.js
@@ -1210,8 +1210,9 @@ var mathlib = (function() {
 
 	function valuedArray(len, val) {
 		var ret = [];
+		var isFun = typeof val == 'function';
 		for (var i = 0; i < len; i++) {
-			ret[i] = val;
+			ret[i] = isFun ? val(i) : val;
 		}
 		return ret;
 	}


### PR DESCRIPTION
Add all possible 256 CIC values for GAN cubes, according to this findings -> https://github.com/cs0x7f/cstimer/pull/370#issuecomment-1963191334

I tested this in the current stable version of Chrome on macOS and Android, and in the Bluefy on iPadOS. Seems like all works fine without issues. We can try to use such approach in the wild and see if any issues pop out, I want to believe should not be any. And it is better to autodetect MAC address in any condition rather than guiding users to unbind cube from account.

Also I've increased timeout for waiting advertising packet when autodetecting MAC address. Some cubes like MoYu AI 2023 has very long advertising interval, and sometimes this timeout is not enough and fired before advertising packet is received from the cube. It is better to wait a bit more rather than giving up early. Increased timeout will not affect responsiveness of cube connection procedure.
