### PR TITLE
Set minimum height for stats panel in mobile view

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -676,6 +676,10 @@ a {
 	width: 100%;
 }
 
+.m .myscroll {
+	min-height: 11em;
+}
+
 .myscroll::-webkit-scrollbar {
 	display: none;
 }


### PR DESCRIPTION
In mobile view minimum height for stats panel is not set.
When session result set is small, only single result row is displayed. This is very inconvenient.
So set minimum height for stats panel that at least 3 rows will be displayed.

| Before| After |
|-------|-------|
| <img width=500 src="https://github.com/cs0x7f/cstimer/assets/4266693/3167df6c-5f64-4333-bad5-11678210e8f2"> | <img width=500 src="https://github.com/cs0x7f/cstimer/assets/4266693/cb793633-fb37-4ac2-bd46-2970054a1d0a"> |
