### PR TITLE
Fix connection issue with QiYi cube on Android

### DIFF
--- a/src/js/hardware/bluetooth.js
+++ b/src/js/hardware/bluetooth.js
@@ -1504,7 +1504,7 @@ var GiikerCube = execMain(function() {
 				}
 			}).then(function() {
 				_chrct_cube.addEventListener('characteristicvaluechanged', onCubeEvent);
-				_chrct_cube.startNotifications();
+				return _chrct_cube.startNotifications();
 			}).then(function() {
 				return sendHello(deviceMac);
 			});


### PR DESCRIPTION
This is just race condition.
Write to the characteristic fails because `startNotification()` is not completed at that point.
You need to wait until `startNotification()` promise is fulfilled.