### PR TITLE
Improve WeiLong V10 Ai support

### DIFF
--- a/src/js/hardware/bluetooth.js
+++ b/src/js/hardware/bluetooth.js
@@ -1532,12 +1532,11 @@ var GiikerCube = execMain(function() {
 		}
 
 		/**
-		 * Automatic MAC address discovery only works in Chrome when the cube is "unbound"
-		 * but enabling it at all (even with just CIC = 0x0100) causes "bound" cubes to not be able to connect.
+		 * Automatic MAC address discovery only works in Chrome when the cube is "bound"
 		 * 
 		 * Proposed explanation:
 		 * 
-		 * When the cube is "bound" in the WCU Cube app, the CIC is 0x0000, otherwise it is 0x0100.
+		 * When the cube is "bound" in the WCU Cube app, the CIC is 0x0100, otherwise it is 0x0000.
 		 * Unfortunately, Chromium has an issue when receiving advertisements with CIC 0x0000
 		 * seemingly related to its use of WTF::HashMap which disallows 0 as a key in this case (IntHashTraits: empty_value = 0).
 		 * 
@@ -1557,16 +1556,11 @@ var GiikerCube = execMain(function() {
 		 *  blink::BluetoothRemoteGATTServer::connect [0x00007FF8DBA03EF5+133]
 		 *  blink::`anonymous namespace'::v8_bluetooth_remote_gatt_server::ConnectOperationCallback [0x00007FF8DA8C69A4+1076]
 		 * 
-		 * Unfortunately, simply receiving an advertisement with CIC 0x0000 after calling watchAdvertisements triggers this.
-		 * This means that we can't simply only use CIC 0x0100 - calling watchAdvertisements at all when the cube is advertising
-		 * with CIC 0x0000 will cause device.gatt.connect() to fail.
 		 */
 
-		var MOYU32_CIC_LIST = [0x0000, 0x0100];
+		var MOYU32_CIC_LIST = [0x0100];
 
 		function waitForAdvs() {
-			return Promise.reject(-1);
-			// See above comment re: Chrome issue
 			if (!_device || !_device.watchAdvertisements) {
 				return Promise.reject(-1);
 			}

--- a/src/js/hardware/bluetooth.js
+++ b/src/js/hardware/bluetooth.js
@@ -1681,6 +1681,20 @@ var GiikerCube = execMain(function() {
 			parseData(value);
 		}
 
+		function initCubeState() {
+			var locTime = $.now();
+			DEBUG && console.log('[Moyu32Cube]', 'initialising cube state');
+			callback(latestFacelet, [], [null, locTime], deviceName);
+			prevCubie.fromFacelet(latestFacelet);
+			prevMoveCnt = moveCnt;
+			if (latestFacelet != kernel.getProp('giiSolved', mathlib.SOLVED_FACELET)) {
+				var rst = kernel.getProp('giiRST');
+				if (rst == 'a' || rst == 'p' && confirm(CONFIRM_GIIRST)) {
+					giikerutil.markSolved();
+				}
+			}
+		}
+
 		function parseData(value) {
 			var locTime = $.now();
 			value = decode(value);
@@ -1700,16 +1714,10 @@ var GiikerCube = execMain(function() {
 				DEBUG && console.log('[Moyu32Cube]', 'Software Version', softwareVersion);
 				DEBUG && console.log('[Moyu32Cube]', 'Device Name', devName);
 			} else if (msgType == 163) { // state (facelets)
-				moveCnt = parseInt(value.slice(152, 160), 2);
-				latestFacelet = parseFacelet(value.slice(8, 152));
-				callback(latestFacelet, [], [null, locTime], deviceName);
-				prevCubie.fromFacelet(latestFacelet);
-				prevMoveCnt = moveCnt;
-				if (latestFacelet != kernel.getProp('giiSolved', mathlib.SOLVED_FACELET)) {
-					var rst = kernel.getProp('giiRST');
-					if (rst == 'a' || rst == 'p' && confirm(CONFIRM_GIIRST)) {
-						giikerutil.markSolved();
-					}
+				if (prevMoveCnt == -1) { // we only care about the initial cube state, ignore any other state messages
+					moveCnt = parseInt(value.slice(152, 160), 2);
+					latestFacelet = parseFacelet(value.slice(8, 152));
+					initCubeState();
 				}
 			} else if (msgType == 164) { // battery level
 				batteryLevel = parseInt(value.slice(8, 16), 2);


### PR DESCRIPTION
As suggested by @afedotov (https://github.com/cs0x7f/cstimer/pull/406#issuecomment-2254612390):

 * Improve WeiLong V10 Ai facelet message handling by only handling the initial facelet state message and ignoring any others (as far as I can tell, the WeiLong V10 Ai only sends the facelet state when requested, but this is just in case 😃 ).
 * Enable automatic MAC address discovery for bound WeiLong V10 Ai smartcubes with bound account IDs greater than 65535.