### PR TITLE
Improve WeiLong V10 Ai automatic MAC address discovery

### DIFF
--- a/src/js/hardware/bluetooth.js
+++ b/src/js/hardware/bluetooth.js
@@ -1602,8 +1602,8 @@ var GiikerCube = execMain(function() {
 							])).then(function () {
 								_chrct_otaread && _chrct_otaread.removeEventListener('characteristicvaluechanged', onChrctValueChanged);
 								_chrct_otaread && _chrct_otaread.stopNotifications().catch($.noop);
-								resolve(mac.join(':'));
 							});
+							resolve(mac.join(':'));
 						}
 					}
 				}

--- a/src/js/hardware/bluetooth.js
+++ b/src/js/hardware/bluetooth.js
@@ -1599,12 +1599,13 @@ var GiikerCube = execMain(function() {
 				}
 
 				_chrct_otaread.addEventListener('characteristicvaluechanged', onChrctValueChanged);
-				_chrct_otaread.startNotifications();
-				_chrct_otawrite.writeValueWithoutResponse(new Uint8Array([
-					0x08, 0x09, 0x00,
-					(JUMP_TABLE_END_ADDR & 0xFF), (JUMP_TABLE_END_ADDR & 0xFF00) >> 8, (JUMP_TABLE_END_ADDR & 0xFF0000) >> 16, (JUMP_TABLE_END_ADDR & 0xFF000000) >> 24,
-					0x04, 0x00
-				])); // read 4 bytes from JUMP_TABLE_END_ADDR to confirm that we're in the right spot
+				_chrct_otaread.startNotifications().then(function() {
+					_chrct_otawrite.writeValueWithoutResponse(new Uint8Array([
+						0x08, 0x09, 0x00,
+						(JUMP_TABLE_END_ADDR & 0xFF), (JUMP_TABLE_END_ADDR & 0xFF00) >> 8, (JUMP_TABLE_END_ADDR & 0xFF0000) >> 16, (JUMP_TABLE_END_ADDR & 0xFF000000) >> 24,
+						0x04, 0x00
+					])); // read 4 bytes from JUMP_TABLE_END_ADDR to confirm that we're in the right spot
+				});
 
 				setTimeout(function () { // reject after 5s if something goes wrong and we can't read the MAC address
 					_chrct_otaread && _chrct_otaread.removeEventListener('characteristicvaluechanged', onChrctValueChanged);


### PR DESCRIPTION
This *should* make automatic MAC address discovery work on all WeiLong V10 Ai smartcubes.

This method takes advantage of being able to perform memory reads via the Freqchip OTA update BLE service. We can read the MAC address from [this struct](https://github.com/freqchip/FR801xH/blob/64ad073d946960eb486245ce25d15067be3e9514/components/modules/platform/include/jump_table.h#L219). 
Unfortunately, the cube takes about 5 seconds to start responding normally again after reading the MAC address, meaning there is a delay after connecting to the cube - however, considering there was already a 10s timeout on manufacturer data-based MAC address discovery, this isn't really a big issue 😄

Tested and working for me on Chrome (Windows, Android) and Bluefy (iOS).