### PR TITLE
Fix race while displaying scramble in smartcube mode

### DIFF
--- a/src/js/tools/bluetoothutil.js
+++ b/src/js/tools/bluetoothutil.js
@@ -73,7 +73,7 @@ var scrHinter = execMain(function(CubieCube) {
 
 	function checkState(state) {
 		if (!rawScrTxt || !GiikerCube.isConnected()
-				|| tools.getCurPuzzle() != '333' || timer.getCurTime() != 0) {
+				|| tools.getCurPuzzle() != '333' || timer.getCurTime() != 0 || timer.getStatus() > 0) {
 			return;
 		}
 		var toMoveFix = null;


### PR DESCRIPTION
Sometimes after first solution move is made, current scramble text is erased and single move displayed instead. This is just race condition. When first solution move event is processed and it is reached to the `scrHinter.checkState()` function, timer time may be still == 0. So just add additional check for timer state.

On the screenshot below logged numbers for `checkState()` invocations are `timer.getStatus()` and `timer.getCurTime()`:

<img width="1552" alt="scramble-race" src="https://github.com/user-attachments/assets/5403dd05-dd3c-443d-98c1-10d043ccffe0">
