### PR TITLE
Even better iCarry2 lost move recovery on edge cases

### DIFF
--- a/src/js/hardware/bluetooth.js
+++ b/src/js/hardware/bluetooth.js
@@ -983,8 +983,12 @@ var GiikerCube = execMain(function() {
 						var diff = (moveCnt - prevMoveCnt) & 0xFF;
 						if (diff > 0) {
 							giikerutil.log('[gancube]', 'v3 cube state is ahead of the last recorded move', prevMoveCnt, moveCnt, diff);
-							if (prevMoveCnt != 255) { // Avoid iCarry2 firmware bug with facelets state event at 255 move counter
-								v3requestMoveHistory((moveCnt + 1) & 0xFF, diff);
+							// Constraint to avoid iCarry2 firmware bug with facelets state event at 255 move counter.
+							// When receiving facelets state with 0 move counter we can't be sure that
+							// move with 0 counter is fulfilled, and wrong move from previous loop may be restored instead.
+							if (moveCnt != 0) {
+								var startMoveCnt = moveBuffer[0] ? moveBuffer[0][0] : (moveCnt + 1) & 0xFF;
+								v3requestMoveHistory(startMoveCnt, diff + 1);
 							}
 						}
 					}


### PR DESCRIPTION
In real world scenarios iCarry2 never misses more than single move in the row, and such worst case accident may be never pops out. But I do stress test to simulate randomly missing moves with 1/3 probability, to be sure all works fine in general. And there may be cases when more than one move missed on the move counter serial loop edge, something like this:

`253 | 254 | missed | missed | 1 | 2`

In such case due iCarry2 firmware bug missed moves can't be restored using single request, you need to split request in two chunks to get moves after 0 and then before 0. So this is improvement to address such issues in case if facelets state event used to trigger missing move recovery.