### PR TITLE
Add GAN V4 gyroscope support

### DIFF
--- a/src/js/hardware/gancube.js
+++ b/src/js/hardware/gancube.js
@@ -1040,6 +1040,34 @@ execMain(function() {
 			giikerutil.log('[gancube]', 'v4 battery level', batteryLevel);
 			giikerutil.updateBattery([batteryLevel, deviceName + '*']);
 		} else if (mode == 0xEC) { // gyro
+			var zero = parseInt(value.slice(0, 16), 2) / 16_384;
+			var one = parseInt(value.slice(16, 32), 2) / 16_384;
+			var two = parseInt(value.slice(32, 48), 2) / 16_384;
+			var three = parseInt(value.slice(48, 64), 2) / 16_384;
+
+			var quaterX = two;
+			var quaterY = one;
+			var quaterZ = three;
+			var quaterW = zero;
+
+			// var wSquared = 1 - (quaterX * quaterX + quaterY * quaterY + quaterZ * quaterZ);
+			// var quaterW = wSquared > 0 ? Math.sqrt(wSquared) : 0;
+
+			var angleSpeedX = parseInt(value.slice(64, 68), 2);
+			var angleSpeedY = parseInt(value.slice(68, 72), 2);
+			var angleSpeedZ = parseInt(value.slice(72, 76), 2);
+
+			var axisX = parseInt(value.slice(76, 97), 2) / 16_384;
+			var axisY = parseInt(value.slice(97, 118), 2) / 16_384;
+			var axisZ = parseInt(value.slice(118, 139), 2) / 16_384;
+			var angle = parseInt(value.slice(139, 160), 2) / 16_384;
+
+			window.puzzleObj.twisty._3d.useQuaternion = true;
+
+			var newQuat = new THREE.Quaternion(quaterX, quaterY, quaterZ, quaterW).normalize();
+			window.puzzleObj.twisty._3d.quaternion = newQuat;
+
+			window.puzzleObj.twistyScene.render()
 		} else {
 			giikerutil.log('[gancube]', 'v4 received unknown event', mode, value);
 		}

--- a/src/js/timer/giiker.js
+++ b/src/js/timer/giiker.js
@@ -44,6 +44,10 @@ execMain(function(timer) {
 					curVRCCubie.selfMoveStr(puzzleObj.move2str(preScramble[i]));
 				}
 				puzzleObj.applyMoves(preScramble); // process pre scramble (cube orientation)
+
+				// temporary hack
+				window.puzzleObj = puzzleObj;
+
 				var targetOri = kernel.getProp('giiOri');
 				targetOri = targetOri == 'auto' ? -1 : ~~targetOri;
 				setOri(targetOri);

--- a/src/js/twisty/twisty.js
+++ b/src/js/twisty/twisty.js
@@ -399,6 +399,8 @@ window.twistyjs = (function() {
 			moveCameraDelta(deltaTheta, 0);
 		}
 
+		this.render = render;
+
 		function render() {
 			renderer.render(scene, camera);
 		}


### PR DESCRIPTION
- [x] Make the virtual cube move with the smart cube
  - [ ] Make it move correctly
- [ ] Refactor code for production
- [ ] Allow toggling gyroscope from settings

Out of scope:

- Use gyroscope to inform virtual reconstruction (VR) orientation
- Include gyroscope data in VR