### PR TITLE
Fix incorrect dates when importing

### DIFF
--- a/src/js/lib/mathlib.js
+++ b/src/js/lib/mathlib.js
@@ -1409,7 +1409,7 @@ var mathlib = (function() {
 		if (!m) {
 			return null;
 		}
-		var date = new Date(0);
+		var date = new Date(1970, 0, 1);
 		date.setFullYear(~~m[1]);
 		date.setMonth(~~m[2] - 1);
 		date.setDate(~~m[3]);


### PR DESCRIPTION
Regarding #497 

Solution: Call `new Date(1970, 0, 1)` instead of `new Date(0)`. This will ensure the newly created date object always represents the **local time** `1970-01-01 00:00:00` (no `1969-12-31` anymore), hence avoiding the `setMonth()` issue.

See reference [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date#syntax):

> Given at least a year and month, this form of Date() returns a Date object whose component values (year, month, day, hour, minute, second, and millisecond) all come from the following parameters. Any missing fields are given the lowest possible value (1 for day and 0 for every other component). **The parameter values are all evaluated against the local time zone, rather than UTC.** [Date.UTC()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/UTC) accepts similar parameters but interprets the components as UTC and returns a timestamp.

I'm not very familiar with the code base, thus decided to make a one-line fix to avoid messing up things :)