### PR TITLE
Enable Spacebar for WCA Inspection in Bluetooth Timer mode

### DIFF
--- a/src/js/timer/bttimer.js
+++ b/src/js/timer/bttimer.js
@@ -113,14 +113,51 @@ execMain(function(timer) {
 	}
 
 	function onKeyUp(keyCode) {
-		if (enable && keyCode == 32 && !BluetoothTimer.isConnected()) {
+		if (!enable) {
+			return;
+		}
+		if (keyCode == 32 && !BluetoothTimer.isConnected()) {
 			showConnectionDialog();
+			return;
+		}
+		var now = $.now();
+		// Start inspection when spacebar is released while in ready-to-inspect state
+		// Only allow if timer is reset (hardTime is 0 or null)
+		if (keyCode == 32 && timer.status() == -4 && timer.checkUseIns() && BluetoothTimer.isConnected() && (timer.hardTime() == 0 || timer.hardTime() == null)) {
+			timer.status(-3);
+			timer.lcd.reset();
+			timer.startTime(now);
+			timer.lcd.fixDisplay(false, true);
+		}
+		if (keyCode == 32) {
+			kernel.clrKey();
+		}
+	}
+
+	function onKeyDown(keyCode) {
+		if (!enable) {
+			return;
+		}
+		var now = $.now();
+		// Start inspection preparation when spacebar is pressed while idle
+		// Only allow if timer is reset (hardTime is 0 or null)
+		if (keyCode == 32 && timer.status() == -1 && timer.checkUseIns() && BluetoothTimer.isConnected() && (timer.hardTime() == 0 || timer.hardTime() == null)) {
+			timer.status(-4);
+			timer.startTime(now);
+			timer.lcd.fixDisplay(true, true);
+		} else if (keyCode == 27 && timer.status() <= -1) {
+			// Cancel inspection or reset when ESC is pressed
+			timer.status(-1);
+			timer.lcd.fixDisplay(true, false);
+		}
+		if (keyCode == 32) {
+			kernel.clrKey();
 		}
 	}
 
 	timer.bttimer = {
 		setEnable: setEnable,
 		onkeyup: onKeyUp,
-		onkeydown: $.noop
+		onkeydown: onKeyDown
 	};
 }, [timer]);


### PR DESCRIPTION
Fixes #513

## Problem
When "Entering in times with" is set to "Bluetooth Timer", the Spacebar is completely disabled. This logic assumes that all Bluetooth timers have internal buttons to start Inspection (like the GAN Timer). However, other popular timers like the QiYi Smart Timer do not have inspection buttons.

Because the keyboard is locked, users with these timers have no way to start WCA Inspection. We are forced to skip inspection entirely.

## Solution
This PR enables the Spacebar to trigger WCA Inspection while in "Bluetooth Timer" mode, matching the behavior of other timer modes (Stackmat, Input).

## Changes
- Added `onKeyDown` handler to detect spacebar press and enter ready-to-inspect state (status -4)
- Added `onKeyUp` handler to start inspection countdown (status -3) when spacebar is released
- Added reset check: inspection can only start when timer is reset (`hardTime == 0 || hardTime == null`)
- ESC key cancels inspection as expected

## How it works
1. User presses Spacebar while idle (only when timer is reset) → enters ready-to-inspect state
2. User releases Spacebar → starts inspection countdown
3. User places hands on Bluetooth timer → timer starts normally

## Testing
- ✅ Spacebar only works when timer is reset (prevents starting inspection before reset)
- ✅ ESC cancels inspection properly
- ✅ Matches behavior of Stackmat and Input timer modes
- ✅ No linting errors

## Current Behavior
- Spacebar is dead ❌

## Desired Behavior (After this PR)
- Spacebar starts inspection → User places hands on Bluetooth timer → Timer starts ✅