### PR TITLE
Fix F2L training timer stop in Bluetooth cube training mode

### DIFF
--- a/src/js/timer/giiker.js
+++ b/src/js/timer/giiker.js
@@ -228,7 +228,9 @@ execMain(function(timer) {
 				'oll': 'oll',
 				'eols': 'oll',
 				'wvls': 'oll',
-				'zbls': 'eoll'
+				'zbls': 'eoll',
+				'f2l': 'f2l',
+				'lsll2': 'f2l'
 			}[curScrType];
 			if (chkstep) {
 				return cubeutil.getStepProgress(chkstep, facelet) == 0;


### PR DESCRIPTION
## Problem

Timer does not stop after completing F2L when using Bluetooth cube with
training mode and F2L training scrambles (f2l, lsll2). Users must solve the
entire cube for timer to stop.

## Solution

Added F2L training support to the chkstep mapping in isGiiSolved() function:
- 'f2l': 'f2l' for F2L training scrambles
- 'lsll2': 'f2l' for F2L single pair scrambles

## Testing

- F2L training: Timer stops after F2L completion
- F2L single pair: Timer stops after F2L completion
- OLL training: No regression
- Normal mode: Still requires full solve as expected

Fixes #501