### PR TITLE
fix: exclude file:// protocol from forced HTTPS redirect (Fixes #537)

### DIFF
--- a/src/js/lib/utillib.js
+++ b/src/js/lib/utillib.js
@@ -93,7 +93,7 @@ ISCSTIMER && execMain(function() {
 		window.localStorage = {};
 	}
 
-	if (!('properties' in localStorage) && location.protocol != 'https:' && location.hostname != 'localhost') {
+	if (!('properties' in localStorage) && location.protocol != 'https:' && location.hostname != 'localhost' && location.protocol != 'file:') {
 		location.href = 'https:' + location.href.substring(location.protocol.length);
 	}
 


### PR DESCRIPTION
### Description

When csTimer is saved as a local HTML file and opened via `file://` protocol, the forced HTTPS redirect logic in `utillib.js` incorrectly triggers, resulting in a broken page (redirects to `https:///...`).

This PR adds a check for `location.protocol != 'file:'` to prevent the redirect when the page is opened locally.

Fixes #537 