### PR TITLE
Discover Bluetooth timers by advertised service UUID

### DIFF
--- a/src/js/hardware/bluetooth.js
+++ b/src/js/hardware/bluetooth.js
@@ -79,6 +79,9 @@ function BtDeviceGroupFactory() {
 			var filters = Object.keys(cubeModels).map((prefix) => ({ namePrefix: prefix }));
 			var opservs = [...new Set(Array.prototype.concat.apply([], Object.values(cubeModels).map((cubeModel) => cubeModel.opservs || [])))];
 			var cics = [...new Set(Array.prototype.concat.apply([], Object.values(cubeModels).map((cubeModel) => cubeModel.cics || [])))];
+			// also match by advertised service, for devices that can't present a model name (e.g. phone timers)
+			var servFilters = [...new Set(Array.prototype.concat.apply([], Object.values(cubeModels).map((cubeModel) => cubeModel.servFilters || [])))];
+			filters = filters.concat(servFilters.map((service) => ({ services: [service] })));
 			giikerutil.log('[bluetooth]', 'scanning...', Object.keys(cubeModels));
 			return window.navigator.bluetooth.requestDevice({
 				filters: filters,
@@ -91,15 +94,22 @@ function BtDeviceGroupFactory() {
 			device.addEventListener('gattserverdisconnected', onDisconnect);
 			cube = null;
 			for (var prefix in cubeModels) {
-				if (device.name.startsWith(prefix)) {
+				if (device.name && device.name.startsWith(prefix)) {
 					cube = cubeModels[prefix];
 					break;
 				}
 			}
-			if (!cube) {
-				return Promise.reject('Cannot detect device type');
+			if (cube) {
+				return cube.init(device);
 			}
-			return cube.init(device);
+			return device.gatt.connect().then((gatt) => gatt.getPrimaryServices()).then(function(servs) {
+				var uuids = servs.map((service) => toUuid128(service.uuid));
+				cube = Object.values(cubeModels).find((model) => (model.servFilters || []).some((s) => uuids.indexOf(toUuid128(s)) >= 0));
+				if (!cube) {
+					return Promise.reject('Cannot detect device type');
+				}
+				return cube.init(device);
+			});
 		});
 	}
 

--- a/src/js/hardware/gantimer.js
+++ b/src/js/hardware/gantimer.js
@@ -116,6 +116,7 @@ var GanTimerDriver = execMain(function () {
 		prefix: ['GAN', 'Gan', 'gan'],
 		init: init,
 		opservs: [SERVICE_UUID],
+		servFilters: [SERVICE_UUID],
 		clear: clear
 	});
 });


### PR DESCRIPTION
Bluetooth timer discovery and dispatch are name-based: the chooser filters by
namePrefix and the selected device is routed via device.name.startsWith(prefix).
This misses GAN-protocol timers when the central doesn't surface the advertised
name as "GAN…" — which depends on the platform/browser, and is always the case
for a phone acting as a GAN timer (iOS lets an app set only the advertised local
name, not the GAP name the central reports).

A driver can now declare servFilters: those service UUIDs are added to the
requestDevice filters too, and a selected device that matches no name prefix is
identified by the GATT service it exposes. Opt-in — only the GAN timer sets it
(its fff0 service), so cubes and the other timer driver behave exactly as before.

Tested with both a phone simulating a GAN timer (advertising the fff0 service)
and a real GAN Smart Timer, on desktop Chrome, Chrome on Android, and Bluefy on
iOS — all discovered and connecting as expected.