### PR TITLE
Fix swapped hardware/software version fields in MoYu32 driver

### DIFF
--- a/src/js/hardware/moyu32cube.js
+++ b/src/js/hardware/moyu32cube.js
@@ -268,9 +268,9 @@ execMain(function() {
 			var devName = '';
 			for (var i = 0; i < 8; i++)
 				devName += String.fromCharCode(parseInt(value.slice(8 + i * 8, 16 + i * 8), 2));
-			var hardwareVersion = parseInt(value.slice(88, 96), 2) + "." + parseInt(value.slice(96, 104), 2);
-			var softwareVersion = parseInt(value.slice(72, 80), 2) + "." + parseInt(value.slice(80, 88), 2);
-			giikerutil.log('[Moyu32Cube] Hardware Version (?)', hardwareVersion);
+			var hardwareVersion = parseInt(value.slice(72, 80), 2) + "." + parseInt(value.slice(80, 88), 2);
+			var softwareVersion = parseInt(value.slice(88, 96), 2) + "." + parseInt(value.slice(96, 104), 2);
+			giikerutil.log('[Moyu32Cube] Hardware Version', hardwareVersion);
 			giikerutil.log('[Moyu32Cube] Software Version', softwareVersion);
 			giikerutil.log('[Moyu32Cube] Device Name', devName);
 		} else if (msgType == 163) { // state (facelets)


### PR DESCRIPTION
The MoYu32 info-packet (`0xa1`) parser reads the software version from
bits 72..87 and hardware from 88..103. This is backwards — the existing
log line even flags the uncertainty with `'Hardware Version (?)'`.

Corrected mapping:
- bits **88..103** = software / firmware revision
- bits **72..87** = hardware (board) revision

This swaps the two `value.slice(...)` ranges and drops the `(?)`.

### How it was confirmed
On a physical WeiLong V10 AI (WCU_MY32), an official-app OTA update bumped
the **bits 88..103** field from `2.8` to `2.12`, and the app displays that
exact value as its "firmware version" (固定版本). The field that changes on
a firmware update is the software/firmware revision, so bits 88..103 are
software — this part is confirmed.

The **bits 72..87** field stayed at `2.1` across the same update. Since it
didn't change and is the remaining version field, it is *assumed* to be the
hardware (board) revision, though this hasn't been directly verified (it
would need comparing two physically different cubes).

This mapping also matches the independent reverse-engineering notes in
https://github.com/lukeburong/weilong-v10-ai-protocol.
