### PR TITLE
bluetooth: make advertisement-based MAC discovery robust (empty packets, non-delivering platforms)

### DIFF
--- a/src/js/hardware/bluetooth.js
+++ b/src/js/hardware/bluetooth.js
@@ -40,6 +40,18 @@ function BtDeviceGroupFactory() {
 		if (!_device || !_device.watchAdvertisements) {
 			return Promise.reject(-1);
 		}
+		// watchAdvertisements() EXISTS on Linux/ChromeOS but never fires
+		// 'advertisementreceived' there, so feature-detecting the method isn't enough.
+		// Web Bluetooth scanning has known implementation issues on those platforms as
+		// of 2026-08; see
+		// https://github.com/WebBluetoothCG/web-bluetooth/blob/main/implementation-status.md
+		// If support lands there later, this platform skip can simply be removed. Until
+		// then, reject early with the existing -1 code so callers fall back to manual
+		// MAC entry without waiting out the 10s timeout.
+		var uaPlatform = navigator.userAgentData && navigator.userAgentData.platform;
+		if (uaPlatform == 'Linux' || uaPlatform == 'Chrome OS') {
+			return Promise.reject(-1);
+		}
 		var abortController = new AbortController();
 		return new Promise(function(resolve, reject) {
 			var onAdvEvent = function(event) {

--- a/src/js/hardware/bluetooth.js
+++ b/src/js/hardware/bluetooth.js
@@ -44,6 +44,15 @@ function BtDeviceGroupFactory() {
 		return new Promise(function(resolve, reject) {
 			var onAdvEvent = function(event) {
 				giikerutil.log('[bluetooth] receive adv event', event);
+				// Manufacturer data rides in only some advertising packets (e.g. ADV_IND
+				// vs SCAN_RSP), and some platforms (Windows/WinRT) deliver them as
+				// separate events - so the first event is frequently empty. Ignore
+				// packets without manufacturer data and keep listening until one carries
+				// it, or until the timeout fires.
+				if (!event.manufacturerData || event.manufacturerData.size == 0) {
+					giikerutil.log('[bluetooth] adv has no manufacturer data, waiting for next');
+					return;
+				}
 				_device && _device.removeEventListener('advertisementreceived', onAdvEvent);
 				abortController.abort();
 				resolve(event.manufacturerData);


### PR DESCRIPTION
## What

Two robustness fixes to `waitForAdvs()`, both around recovering a cube's MAC
from BLE advertisements.

### 1. Wait for a packet that actually carries manufacturer data

`waitForAdvs()` resolved on the **first** `advertisementreceived` event and
returned `event.manufacturerData` unconditionally. But manufacturer data rides
in only some advertising packets (e.g. `ADV_IND` vs `SCAN_RSP`), and on
Windows/WinRT those arrive as **separate events** — so the first event is
frequently empty. When it was, MAC auto-detection failed and the user got the
manual-MAC prompt even though the data arrived a packet later.

Now it ignores events with empty `manufacturerData` and keeps listening until
one carries data; the existing 10s timeout still handles "never arrived".

### 2. Skip discovery on platforms that don't deliver advertisements

`watchAdvertisements()` **exists** on Linux and ChromeOS but never fires
`advertisementreceived` there, so feature-detecting the method isn't enough —
callers waited out the full 10s timeout before falling back to manual entry.
Web Bluetooth scanning has known implementation issues on those platforms, per
the impl-status doc:
https://github.com/WebBluetoothCG/web-bluetooth/blob/main/implementation-status.md

Now it detects those platforms via `navigator.userAgentData.platform` and
rejects early with the existing `-1` code, so the fallback prompt appears
instantly. Unknown/other platforms are unaffected and still attempt discovery,
so this degrades gracefully if scanning support lands there later.

## Testing

Cube: **MoYu WeiLong v10 AI** (`WCU_MY32…`).

- **Windows / Chrome 151**: manufacturer data was present in only ~half of the
  advertising packets (`ADV_IND` vs `SCAN_RSP`) — fix 1 makes detection
  reliable instead of a coin flip. `watchAdvertisements` works here (matches the
  impl-status table).
- **Linux / Chromium 151**: `watchAdvertisements` exists but delivers zero
  `advertisementreceived` events (matches the empty Linux cell in the table) —
  fix 2 removes the pointless 10s wait before the prompt.
- **Chrome OS: not tested** — skipped on the basis of the impl-status table
  (empty cell = unsupported), same rationale as Linux.
- **macOS: not tested, and NOT skipped** — the table marks it supported, so we
  leave discovery enabled there. If anyone finds it doesn't actually deliver on
  macOS, it can be added to the skip list.
